### PR TITLE
fix: replace missing components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
-import SiteHeader from '../components/SiteHeader'
-import SiteFooter from '../components/SiteFooter'
+import SiteHeader from '@/components/SiteHeader'
+import SiteFooter from '@/components/SiteFooter'
 
 export const metadata: Metadata = {
   title: 'Zmiana KRS',

--- a/components/GoToHeader.tsx
+++ b/components/GoToHeader.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Link from 'next/link'
+
+interface GoToHeaderProps {
+  href: string
+  label: string
+}
+
+export default function GoToHeader({ href, label }: GoToHeaderProps) {
+  return <Link href={href}>{label}</Link>
+}

--- a/components/Mascot.tsx
+++ b/components/Mascot.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Mascot() {
+  return <span role="img" aria-label="mascot">🤖</span>
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Navbar() {
+  return <nav />
+}

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function ThemeSwitcher() {
+  return <button aria-label="Switch Theme" />
+}

--- a/components/TitleHeader.tsx
+++ b/components/TitleHeader.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function TitleHeader({ title }: { title: string }) {
+  return <h1>{title}</h1>
+}


### PR DESCRIPTION
## Summary
- update layout to use existing components via path aliases
- add placeholder Navbar, ThemeSwitcher, TitleHeader, GoToHeader, and Mascot components
- ignore build and dependency directories

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aca2384b388330ac561ec22e8017f4