### PR TITLE
feat: import metadata type in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
-import './globals.css'
 import type { Metadata } from 'next'
+import './globals.css'
 import SiteHeader from '@/components/SiteHeader'
 import SiteFooter from '@/components/SiteFooter'
 


### PR DESCRIPTION
## Summary
- import Metadata type at top of app layout to type metadata export

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aca66ddf10833080a190ee16a8996f