### PR TITLE
refactor: handle redirects in next config

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,24 +1,13 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-const redirects: Record<string, string> = {
-  '/kontakt': '/contact',
-  '/dla-ksiegowych': '/ksiegowi',
-}
-
 export function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl
   const host = request.headers.get('host') || ''
   // On Vercel, use VERCEL_ENV to detect preview vs production
   const isProd = process.env.VERCEL_ENV === 'production'
   const isVercelPreview = host.endsWith('.vercel.app')
 
-  // 1) Handle path redirects
-  if (redirects[pathname]) {
-    return NextResponse.redirect(new URL(redirects[pathname], request.url), 301)
-  }
-
-  // 2) Force WWW only on the real custom domain in production (not on *.vercel.app previews)
+  // Force WWW only on the real custom domain in production (not on *.vercel.app previews)
   if (isProd && !isVercelPreview && !host.startsWith('www.')) {
     const url = new URL(request.url)
     url.host = `www.${host}`

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,20 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   experimental: { typedRoutes: false },
+  async redirects() {
+    return [
+      {
+        source: '/kontakt',
+        destination: '/contact',
+        statusCode: 301,
+      },
+      {
+        source: '/dla-ksiegowych',
+        destination: '/ksiegowi',
+        statusCode: 301,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- remove custom redirect map from middleware
- add 301 redirects for `/kontakt` and `/dla-ksiegowych`
- keep middleware to enforce `www` subdomain only

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad822ed94c8330ad7c93f46b5eda5f