### PR TITLE
feat: set metadataBase from environment

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,9 @@ import SiteHeader from '@/components/SiteHeader'
 import SiteFooter from '@/components/SiteFooter'
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://moja-strona-nextjs.vercel.app'
+  ),
   title: 'Zmiana KRS',
   description: 'Profesjonalna obsługa zmian w KRS.',
 }


### PR DESCRIPTION
## Summary
- configure `metadataBase` using `NEXT_PUBLIC_SITE_URL` with fallback url

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find package 'remark-gfm')*

------
https://chatgpt.com/codex/tasks/task_e_68ad98a7548c8330aa16e882a19ce095