### PR TITLE
Remove redundant next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,0 @@
-import { withContentlayer } from 'next-contentlayer'
-
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  experimental: { typedRoutes: false },
-}
-
-export default withContentlayer(nextConfig)


### PR DESCRIPTION
## Summary
- remove legacy `next.config.mjs`
- rely on `next.config.ts` with `withContentlayer` and 301 redirects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ad99b0679083309344b7e03b89bcb0