### PR TITLE
Add URL computed field to contentlayer config

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -19,6 +19,10 @@ export const Post = defineDocumentType(() => ({
       type: 'string',
       resolve: (doc) => doc._raw.flattenedPath,
     },
+    url: {
+      type: 'string',
+      resolve: (doc) => `/blog/${doc._raw.flattenedPath}`,
+    },
   },
 }))
 


### PR DESCRIPTION
## Summary
- compute canonical URLs for posts in contentlayer config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ecce4b08330af15dd0c6a3813e1