### PR TITLE
Remove default base URL fallback

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,8 +2,11 @@ import type { MetadataRoute } from "next";
 import { allPosts } from "contentlayer/generated";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const BASE_URL =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://www.zmianakrs.pl";
+  const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL;
+
+  if (!BASE_URL) {
+    throw new Error("NEXT_PUBLIC_SITE_URL env variable is not set");
+  }
 
   const routes = [
     "",


### PR DESCRIPTION
## Summary
- remove hardcoded fallback base URL from sitemap
- throw error when NEXT_PUBLIC_SITE_URL missing

## Testing
- `npm test` (fails: missing script)
- `NEXT_PUBLIC_SITE_URL=https://example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ada8f579d48330ac60f67d96881798