### PR TITLE
Normalize BASE_URL in sitemap to avoid trailing slash

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,6 +8,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     throw new Error("NEXT_PUBLIC_SITE_URL env variable is not set");
   }
 
+  const baseUrl = BASE_URL.replace(/\/$/, "");
+
   const routes = [
     "",
     "/blog",
@@ -20,12 +22,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/cennik",
     "/uslugi",
   ].map((path) => ({
-    url: `${BASE_URL}${path}`,
+    url: `${baseUrl}${path}`,
     lastModified: new Date(),
   }));
 
   const posts = allPosts.map((post) => ({
-    url: `${BASE_URL}/blog/${post.slug}`,
+    url: `${baseUrl}/blog/${post.slug}`,
     lastModified: new Date(post.date),
   }));
 


### PR DESCRIPTION
## Summary
- sanitize `NEXT_PUBLIC_SITE_URL` by removing a trailing slash
- generate sitemap URLs using the sanitized base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68adaa4f1cf0833098ffedc8380f6ae5