### PR TITLE
Use deterministic dates for static routes in sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,8 @@
 import type { MetadataRoute } from "next";
 import { allPosts } from "contentlayer/generated";
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL;
@@ -10,21 +13,44 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const baseUrl = BASE_URL.replace(/\/$/, "");
 
-  const routes = [
-    "",
-    "/blog",
-    "/polityka-prywatnosci",
-    "/regulamin",
-    "/contact",
-    "/ksiegowi",
-    "/rodo",
-    "/o-nas",
-    "/cennik",
-    "/uslugi",
-  ].map((path) => ({
-    url: `${baseUrl}${path}`,
-    lastModified: new Date(),
+  const routeFileMap: Record<string, string> = {
+    "": "app/(site)/page.tsx",
+    "/blog": "app/blog/page.tsx",
+    "/polityka-prywatnosci": "app/(site)/polityka-prywatnosci/page.tsx",
+    "/regulamin": "app/(site)/regulamin/page.tsx",
+    "/contact": "app/(site)/contact/page.tsx",
+    "/ksiegowi": "app/(site)/ksiegowi/page.tsx",
+    "/rodo": "app/(site)/rodo/page.tsx",
+    "/o-nas": "app/(site)/o-nas/page.tsx",
+    "/cennik": "app/(site)/cennik/page.tsx",
+    "/uslugi": "app/(site)/uslugi/page.tsx",
+  };
+
+  const routes = Object.entries(routeFileMap).map(([route, file]) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: getLastModifiedDate(file),
   }));
+
+  function getLastModifiedDate(relativePath: string): Date {
+    const filePath = path.resolve(process.cwd(), relativePath);
+    try {
+      const gitDate = execSync(`git log -1 --format=%cI -- "${filePath}"`).toString().trim();
+      if (gitDate) {
+        return new Date(gitDate);
+      }
+    } catch (error) {
+      // ignore
+    }
+
+    try {
+      const stats = fs.statSync(filePath);
+      return stats.mtime;
+    } catch (error) {
+      // ignore
+    }
+
+    return new Date("2024-01-01");
+  }
 
   const posts = allPosts.map((post) => ({
     url: `${baseUrl}/blog/${post.slug}`,


### PR DESCRIPTION
## Summary
- use git or filesystem last modification dates instead of `new Date()` for static routes in sitemap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68adab767f8c83308da1c4eff858c80f