### PR TITLE
Use NEXT_PUBLIC_SITE_URL for robots sitemap

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,11 +1,14 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const BASE_URL =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://www.zmianakrs.pl";
+  const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL;
+
+  if (!BASE_URL) {
+    throw new Error("NEXT_PUBLIC_SITE_URL env variable is not set");
+  }
 
   return {
     rules: { userAgent: "*", allow: "/" },
-    sitemap: `${BASE_URL}/sitemap.xml`,
+    sitemap: `${BASE_URL.replace(/\/$/, "")}/sitemap.xml`,
   };
 }


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_SITE_URL` for robots sitemap
- require `NEXT_PUBLIC_SITE_URL` to be defined

## Testing
- `NEXT_PUBLIC_SITE_URL=https://example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adac780d008330880148437caecfd1