### PR TITLE
refactor: revert Next.js config to .mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,23 +1,16 @@
-import { withContentlayer } from 'next-contentlayer'
+import { withContentlayer } from "next-contentlayer"
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: { typedRoutes: false },
+  experimental: { mdxRs: true },
   async redirects() {
     return [
-      {
-        source: '/kontakt',
-        destination: '/contact',
-        statusCode: 301,
-      },
-      {
-        source: '/dla-ksiegowych',
-        destination: '/ksiegowi',
-        statusCode: 301,
-      },
+      { source: "/kontakt", destination: "/contact", permanent: true },
+      { source: "/dla-ksiegowych", destination: "/ksiegowi", permanent: true },
     ]
   },
 }
 
 export default withContentlayer(nextConfig)
+


### PR DESCRIPTION
## Summary
- revert Next.js config to .mjs with Contentlayer wrapper
- enable mdxRs and set permanent redirects

## Testing
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68adb3f7e7dc833089816b3795ae1f19