### PR TITLE
feat: include mdx content path in Tailwind config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./content/**/*.mdx",
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- include the `content` directory's MDX files in Tailwind's scan paths

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: NEXT_PUBLIC_SITE_URL env variable is not set)


------
https://chatgpt.com/codex/tasks/task_e_68adb55e5bf88330be9bccacdbf9e31f