### PR TITLE
feat: add full homepage layout

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -24,58 +24,128 @@ export const metadata: Metadata = {
   },
 };
 
-const nav = [
-  { href: "/", label: "Strona główna" },
-  { href: "/o-nas", label: "O nas" },
-  { href: "/uslugi", label: "Usługi" },
-  { href: "/cennik", label: "Cennik" },
-  { href: "/blog", label: "Blog" },
-  { href: "/ksiegowi", label: "Dla księgowych" },
-  { href: "/contact", label: "Kontakt" },
-];
-
 export default function HomePage() {
   return (
-    <>
-      <header className="border-b bg-white/80 backdrop-blur sticky top-0 z-20">
-        <nav className="max-w-6xl mx-auto px-4 h-14 flex items-center gap-4 overflow-x-auto">
-          <div className="font-semibold">ZmianaKRS</div>
-          <ul className="flex items-center gap-4 text-sm">
-            {nav.map((item) => (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  className="text-gray-600 hover:text-black"
-                >
-                  {item.label}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </nav>
-      </header>
-      <main className="p-8">
-        <h1 className="text-2xl font-semibold">Strona główna (placeholder)</h1>
-        <p className="mt-2 text-sm text-gray-600">App Router działa.</p>
-        <img
-          src="/images/Profesjonalna-poczekalnia-prawnicza-z-eleganckimi-krzeslami-atmosfera-zaufania.webp"
-          alt="Profesjonalna poczekalnia prawnicza z eleganckimi krzesłami"
-          className="mt-4"
-        />
-      </main>
-      <footer className="border-t mt-12 py-8 text-sm text-gray-600">
-        <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row justify-between gap-2">
-          <p>© {new Date().getFullYear()} ZmianaKRS</p>
-          <p>
-            <a className="hover:underline" href="/polityka-prywatnosci">
-              Polityka prywatności
-            </a>{" "}•{" "}
-            <a className="hover:underline" href="/regulamin">
-              Regulamin
-            </a>
-          </p>
+    <main>
+      <section className="bg-gray-50">
+        <div className="max-w-6xl mx-auto px-4 py-20 grid md:grid-cols-2 gap-8 items-center">
+          <div>
+            <h1 className="text-3xl font-semibold">Zmiany w KRS bez stresu</h1>
+            <p className="mt-4 text-gray-600">
+              Aktualizacja danych spółki nigdy nie była prostsza. Zapewniamy
+              profesjonalne wsparcie na każdym etapie.
+            </p>
+            <div className="mt-6 flex gap-4">
+              <Link
+                href="/contact"
+                className="px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+              >
+                Skontaktuj się
+              </Link>
+              <Link
+                href="/uslugi"
+                className="px-6 py-3 border border-blue-600 text-blue-600 rounded-md hover:bg-blue-50"
+              >
+                Poznaj usługi
+              </Link>
+            </div>
+          </div>
+          <div>
+            <img
+              src="/images/Profesjonalna-poczekalnia-prawnicza-z-eleganckimi-krzeslami-atmosfera-zaufania.webp"
+              alt=""
+              className="rounded-lg shadow-md"
+            />
+          </div>
         </div>
-      </footer>
-    </>
+      </section>
+
+      <section className="py-20">
+          <div className="max-w-6xl mx-auto px-4">
+          <h2 className="text-2xl font-semibold text-center mb-12">
+            Dlaczego warto z nami współpracować?
+          </h2>
+          <div className="grid md:grid-cols-3 gap-8">
+            <div className="text-center">
+              <img
+                src="/images/konsultacja-w-zakresie-zmiany-wpisu-do-krs.webp"
+                alt="Konsultacja w zakresie zmian KRS"
+                loading="lazy"
+                className="mx-auto mb-4 rounded-lg"
+              />
+              <h3 className="font-semibold mb-2">Eksperckie doradztwo</h3>
+              <p className="text-sm text-gray-600">
+                Doświadczony zespół specjalistów przeprowadzi Cię przez cały
+                proces zmian.
+              </p>
+            </div>
+            <div className="text-center">
+              <img
+                src="/images/archiwum-dokumenty-spolek-zmiana-wpisu-krs.webp"
+                alt="Archiwum dokumentów spółek"
+                loading="lazy"
+                className="mx-auto mb-4 rounded-lg"
+              />
+              <h3 className="font-semibold mb-2">Kompleksowa obsługa</h3>
+              <p className="text-sm text-gray-600">
+                Zadbamy o przygotowanie dokumentów i ich prawidłowe złożenie w
+                sądzie.
+              </p>
+            </div>
+            <div className="text-center">
+              <img
+                src="/images/outsourcing-zmian-krs-kompleksowa-obsluga-dla-przedsiebiorcow-i-ksiegowych.webp"
+                alt="Outsourcing zmian KRS"
+                loading="lazy"
+                className="mx-auto mb-4 rounded-lg"
+              />
+              <h3 className="font-semibold mb-2">Oszczędność czasu</h3>
+              <p className="text-sm text-gray-600">
+                Skup się na prowadzeniu biznesu, a formalności zostaw nam.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-gray-50 py-20">
+        <div className="max-w-6xl mx-auto px-4 grid md:grid-cols-2 gap-8 items-center">
+          <div>
+            <img
+              src="/images/prawniczka-analizuje-dokumenty-aktualizacja-krs.webp"
+              alt="Prawniczka analizująca dokumenty"
+              loading="lazy"
+              className="rounded-lg shadow-md"
+            />
+          </div>
+          <div>
+            <h2 className="text-2xl font-semibold mb-4">Proces krok po kroku</h2>
+            <p className="text-sm text-gray-600 mb-4">
+              Od pierwszej konsultacji po finalne złożenie wniosku - jesteśmy z
+              Tobą.
+            </p>
+            <ul className="space-y-2 text-sm text-gray-600 list-disc pl-5">
+              <li>Analiza potrzeb i dokumentów</li>
+              <li>Przygotowanie odpowiednich formularzy</li>
+              <li>Weryfikacja i wysyłka do sądu</li>
+              <li>Monitorowanie postępu sprawy</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20 text-center">
+        <h2 className="text-2xl font-semibold mb-4">Gotowy na zmianę?</h2>
+        <p className="text-sm text-gray-600 mb-8">
+          Skontaktuj się z nami i dowiedz się, jak możemy pomóc Twojej spółce.
+        </p>
+        <Link
+          href="/contact"
+          className="inline-block px-8 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+        >
+          Skontaktuj się
+        </Link>
+      </section>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- replace placeholder with full homepage sections and hero image
- ensure only hero image loads eagerly and others lazily

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: NEXT_PUBLIC_SITE_URL env variable is not set)

------
https://chatgpt.com/codex/tasks/task_e_68adeb2918108330817edad392211817