### PR TITLE
Route contact buttons through /kontakt

### DIFF
--- a/components/CTA.tsx
+++ b/components/CTA.tsx
@@ -9,7 +9,7 @@ export default function CTA() {
         Skontaktuj się z nami i dowiedz się, jak możemy pomóc Twojej spółce.
       </p>
       <Link
-        href="/contact"
+        href="/kontakt"
         className="inline-block px-8 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700"
       >
         Skontaktuj się

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -13,7 +13,7 @@ export default function Hero() {
           </p>
           <div className="mt-6 flex gap-4">
             <Link
-              href="/contact"
+              href="/kontakt"
               className="px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700"
             >
               Skontaktuj się


### PR DESCRIPTION
## Summary
- Link contact buttons to the `/kontakt` route using Next.js `Link`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adfce084d08330b9690d0dcc8a7d98