### PR TITLE
refactor: use Next.js Image component for images

### DIFF
--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Image from 'next/image'
 
 export default function Features() {
   return (
@@ -9,10 +10,11 @@ export default function Features() {
         </h2>
         <div className="grid md:grid-cols-3 gap-8">
           <div className="text-center">
-            <img
+            <Image
               src="/images/konsultacja-w-zakresie-zmiany-wpisu-do-krs.webp"
               alt="Konsultacja w zakresie zmian KRS"
-              loading="lazy"
+              width={1536}
+              height={1024}
               className="mx-auto mb-4 rounded-lg"
             />
             <h3 className="font-semibold mb-2">Eksperckie doradztwo</h3>
@@ -22,10 +24,11 @@ export default function Features() {
             </p>
           </div>
           <div className="text-center">
-            <img
+            <Image
               src="/images/archiwum-dokumenty-spolek-zmiana-wpisu-krs.webp"
               alt="Archiwum dokumentów spółek"
-              loading="lazy"
+              width={1024}
+              height={1536}
               className="mx-auto mb-4 rounded-lg"
             />
             <h3 className="font-semibold mb-2">Kompleksowa obsługa</h3>
@@ -35,10 +38,11 @@ export default function Features() {
             </p>
           </div>
           <div className="text-center">
-            <img
+            <Image
               src="/images/outsourcing-zmian-krs-kompleksowa-obsluga-dla-przedsiebiorcow-i-ksiegowych.webp"
               alt="Outsourcing zmian KRS"
-              loading="lazy"
+              width={1536}
+              height={1024}
               className="mx-auto mb-4 rounded-lg"
             />
             <h3 className="font-semibold mb-2">Oszczędność czasu</h3>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 
 export default function Hero() {
   return (
@@ -27,9 +28,12 @@ export default function Hero() {
           </div>
         </div>
         <div>
-          <img
+          <Image
             src="/images/Profesjonalna-poczekalnia-prawnicza-z-eleganckimi-krzeslami-atmosfera-zaufania.webp"
-            alt=""
+            alt="Profesjonalna poczekalnia prawnicza z eleganckimi krzesłami"
+            width={2400}
+            height={1800}
+            priority
             className="rounded-lg shadow-md"
           />
         </div>

--- a/components/Process.tsx
+++ b/components/Process.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
+import Image from 'next/image'
 
 export default function Process() {
   return (
     <section className="bg-gray-50 py-20">
       <div className="max-w-6xl mx-auto px-4 grid md:grid-cols-2 gap-8 items-center">
         <div>
-          <img
+          <Image
             src="/images/prawniczka-analizuje-dokumenty-aktualizacja-krs.webp"
             alt="Prawniczka analizująca dokumenty"
-            loading="lazy"
+            width={1536}
+            height={1024}
             className="rounded-lg shadow-md"
           />
         </div>


### PR DESCRIPTION
## Summary
- replace `img` tags in hero, features, and process components with Next.js `Image`
- add descriptive alt text and explicit width/height
- eagerly load hero image with `priority`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: TypeError: The "code" argument must be of type number. Received an instance of Object)


------
https://chatgpt.com/codex/tasks/task_e_68adfdcea52c83308beaf48cc9341661