### PR TITLE
Add Footer, HeadMeta, and SEO expandable section components

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function Footer() {
+  return (
+    <footer className="border-t mt-12 py-8 text-sm text-gray-600">
+      <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row justify-between gap-2">
+        <p>© {new Date().getFullYear()} ZmianaKRS</p>
+        <p><a className="hover:underline" href="/polityka-prywatnosci">Polityka prywatności</a> • <a className="hover:underline" href="/regulamin">Regulamin</a></p>
+      </div>
+    </footer>
+  )
+}

--- a/components/HeadMeta.tsx
+++ b/components/HeadMeta.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import Head from 'next/head'
+
+interface HeadMetaProps {
+  title: string
+  description?: string
+  keywords?: string
+}
+
+export default function HeadMeta({ title, description, keywords }: HeadMetaProps) {
+  return (
+    <Head>
+      <title>{title}</title>
+      {description && <meta name="description" content={description} />}
+      {keywords && <meta name="keywords" content={keywords} />}
+    </Head>
+  )
+}

--- a/components/SEOExpandableSection.tsx
+++ b/components/SEOExpandableSection.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react'
+
+interface SEOExpandableSectionProps {
+  title: string
+  children: React.ReactNode
+}
+
+export default function SEOExpandableSection({ title, children }: SEOExpandableSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <section className="my-8">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left font-semibold"
+        aria-expanded={expanded}
+      >
+        {title}
+      </button>
+      {expanded && <div className="mt-2 text-sm text-gray-700">{children}</div>}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- reintroduce footer as reusable component
- add expandable section component for SEO content
- add generic head metadata component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: NEXT_PUBLIC_SITE_URL env variable is not set)


------
https://chatgpt.com/codex/tasks/task_e_68adffcdca748330b75da3473df47f72