### PR TITLE
Use Next.js Link for internal navigation

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import Hero from "@/components/Hero"
 import Features from "@/components/Features"
 import Process from "@/components/Process"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,11 +1,20 @@
 import React from 'react'
+import Link from 'next/link'
 
 export default function Footer() {
   return (
     <footer className="border-t mt-12 py-8 text-sm text-gray-600">
       <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row justify-between gap-2">
         <p>© {new Date().getFullYear()} ZmianaKRS</p>
-        <p><a className="hover:underline" href="/polityka-prywatnosci">Polityka prywatności</a> • <a className="hover:underline" href="/regulamin">Regulamin</a></p>
+        <p>
+          <Link className="hover:underline" href="/polityka-prywatnosci">
+            <span>Polityka prywatności</span>
+          </Link>
+          {' '}•{' '}
+          <Link className="hover:underline" href="/regulamin">
+            <span>Regulamin</span>
+          </Link>
+        </p>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
- import `Link` in the main site page
- switch footer anchors to Next.js `Link` with span wrappers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0660023c8330bd97d8e95005d738