### PR TITLE
Wrap homepage JSX in return block

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -32,6 +32,7 @@ export default function HomePage() {
       ],
     },
   };
+  return (
     <div className="min-h-screen relative">
       <HeadMeta
         title="Zmiana wpisu w KRS bez stresu - profesjonalna obsługa wniosków | ZmianaKRS"


### PR DESCRIPTION
## Summary
- ensure `HomePage` component returns its JSX by wrapping markup in a `return` block

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Property 'canonicalUrl' does not exist on type 'HeadMetaProps')*

------
https://chatgpt.com/codex/tasks/task_e_68ae1a30182483309ff3ea0085779dda