### PR TITLE
feat: enhance head metadata

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -32,6 +32,7 @@ export default function HomePage() {
       ],
     },
   };
+  return (
     <div className="min-h-screen relative">
       <HeadMeta
         title="Zmiana wpisu w KRS bez stresu - profesjonalna obsługa wniosków | ZmianaKRS"
@@ -249,14 +250,15 @@ export default function HomePage() {
         </div>
       </section>
 
-                  <SEOExpandableSection
+                    <SEOExpandableSection
+        title="Profesjonalna obsługa zmian wpisu w KRS"
         content={`Profesjonalna obsługa zmian wpisu w KRS dla spółek i biur rachunkowych
 
 Oferujemy kompleksową pomoc w zmianie wpisu w Krajowym Rejestrze Sądowym (KRS)...`}
         pageId="home"
       />
 
-      <Footer />
-    </div>
-  );
-}
+        <Footer />
+      </div>
+    );
+  }

--- a/components/HeadMeta.tsx
+++ b/components/HeadMeta.tsx
@@ -5,14 +5,38 @@ interface HeadMetaProps {
   title: string
   description?: string
   keywords?: string
+  canonicalUrl?: string
+  ogTitle?: string
+  ogDescription?: string
+  ogImage?: string
+  structuredData?: Record<string, any>
 }
 
-export default function HeadMeta({ title, description, keywords }: HeadMetaProps) {
+export default function HeadMeta({
+  title,
+  description,
+  keywords,
+  canonicalUrl,
+  ogTitle,
+  ogDescription,
+  ogImage,
+  structuredData,
+}: HeadMetaProps) {
   return (
     <Head>
       <title>{title}</title>
       {description && <meta name="description" content={description} />}
       {keywords && <meta name="keywords" content={keywords} />}
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+      {ogTitle && <meta property="og:title" content={ogTitle} />}
+      {ogDescription && <meta property="og:description" content={ogDescription} />}
+      {ogImage && <meta property="og:image" content={ogImage} />}
+      {structuredData && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
+      )}
     </Head>
   )
 }


### PR DESCRIPTION
## Summary
- expand `HeadMeta` with canonical, Open Graph and structured data support
- ensure home page returns JSX and provide title to `SEOExpandableSection`

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `NEXT_PUBLIC_SITE_URL=https://example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ba36c1083308f702da29a34cfd2