### PR TITLE
Fix stray line after SEOExpandableSection import

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -4,7 +4,8 @@ import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
 import Features from "@/components/Features";
 import Footer from "@/components/Footer";
-import SEOExpandableSection from "@/components/seo-expandable-section"; // UWAGA: nazwa pliku jest z myślnikami i małymi literami
+// UWAGA: nazwa pliku jest z myślnikami i małymi literami
+import SEOExpandableSection from "@/components/seo-expandable-section";
 import HeadMeta from "@/components/HeadMeta";
 export default function HomePage() {
   const homeJsonLd = {


### PR DESCRIPTION
## Summary
- Move the SEOExpandableSection filename comment onto its own line and remove stray line content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e48205883309700e3a4fe937c09