### PR TITLE
Use router for contact CTA

### DIFF
--- a/components/CTA.tsx
+++ b/components/CTA.tsx
@@ -1,19 +1,22 @@
-import React from 'react'
-import Link from 'next/link'
+"use client"
+
+import React from "react"
+import { useRouter } from "next/navigation"
 
 export default function CTA() {
+  const router = useRouter()
   return (
     <section className="py-20 text-center">
       <h2 className="text-2xl font-semibold mb-4">Gotowy na zmianę?</h2>
       <p className="text-sm text-gray-600 mb-8">
         Skontaktuj się z nami i dowiedz się, jak możemy pomóc Twojej spółce.
       </p>
-      <Link
-        href="/kontakt"
+      <button
+        onClick={() => router.push("/kontakt")}
         className="inline-block px-8 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700"
       >
-        Skontaktuj się
-      </Link>
+        Skontaktuj się z nami
+      </button>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- navigate to kontakt page via Next.js router in CTA component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ae225bd11883308d4e8fa60b52c63e