### PR TITLE
refactor: standardize home page image handling

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -48,7 +48,7 @@ export default function HomePage() {
       <div className="fixed inset-0 -z-10">
         <Image
           src="/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp"
-          alt="Nowoczesne biuro - profesjonalne usługi KRS - obsługa wniosków o zmianę wpisu w KRS"
+          alt=""
           fill
           priority
           className="object-cover object-center"


### PR DESCRIPTION
## Summary
- use empty alt for decorative hero background image

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: NEXT_PUBLIC_SITE_URL env variable is not set)


------
https://chatgpt.com/codex/tasks/task_e_68ae23e21ef883309b33938d88fe9f37