### PR TITLE
feat: restore hero section with overlay

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -14,9 +14,9 @@ export default function Hero() {
       />
       <div className="absolute inset-0 bg-slate-900/70" />
 
-      <div className="relative z-10 max-w-3xl mx-auto text-white">
-        <h1 className="text-4xl sm:text-5xl font-bold">
-          Zmiana wpisu w KRS bez stresu
+      <div className="relative z-10 max-w-4xl mx-auto text-white">
+        <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold leading-tight">
+          Zmiana wpisu w KRS bez stresu i zbędnych formalności
         </h1>
         <p className="mt-6 text-lg sm:text-xl text-gray-200">
           Kompleksowa obsługa wniosków o zmianę danych spółki – szybko,
@@ -26,7 +26,7 @@ export default function Hero() {
         <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
           <Link
             href="/cennik"
-            className="px-8 py-3 bg-amber-600 hover:bg-amber-700 rounded-md text-white font-medium"
+            className="px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-md text-white font-medium"
           >
             Sprawdź cennik
           </Link>
@@ -38,7 +38,7 @@ export default function Hero() {
           </Link>
           <Link
             href="/kontakt"
-            className="px-8 py-3 bg-white text-amber-600 hover:bg-gray-100 rounded-md font-medium"
+            className="px-8 py-3 bg-white text-blue-600 hover:bg-gray-100 rounded-md font-medium"
           >
             Skontaktuj się
           </Link>


### PR DESCRIPTION
## Summary
- restore long headline and hero layout
- harmonize buttons with blue styling

## Testing
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aef05fcf088330b7bf7ead5495266c