### PR TITLE
Use Next.js Link for contact CTA

### DIFF
--- a/components/CTA.tsx
+++ b/components/CTA.tsx
@@ -1,22 +1,21 @@
 "use client"
 
 import React from "react"
-import { useRouter } from "next/navigation"
+import Link from "next/link"
 
 export default function CTA() {
-  const router = useRouter()
   return (
     <section className="py-20 text-center">
       <h2 className="text-2xl font-semibold mb-4">Gotowy na zmianę?</h2>
       <p className="text-sm text-gray-600 mb-8">
         Skontaktuj się z nami i dowiedz się, jak możemy pomóc Twojej spółce.
       </p>
-      <button
-        onClick={() => router.push("/kontakt")}
+      <Link
+        href="/kontakt"
         className="inline-block px-8 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700"
       >
         Skontaktuj się z nami
-      </button>
+      </Link>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- use `next/link` in CTA section for navigation to contact page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aef1c65560833089894ccc467f21fe