### PR TITLE
refactor: align hero CTA buttons with legacy styles

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -39,7 +39,7 @@ export default function Hero() {
           </Link>
           <Link
             href="#jak-dzialamy"
-            className="px-8 py-3 bg-white/10 hover:bg-white/20 border border-white/20 rounded-md text-white font-medium"
+            className="px-8 py-3 border border-white/20 rounded-md text-white font-medium hover:bg-white/10"
           >
             Jak działamy?
           </Link>


### PR DESCRIPTION
## Summary
- adjust Hero component CTA button styles so secondary button has no default background, letting buttons sit directly on the hero background

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: NEXT_PUBLIC_SITE_URL env variable is not set)


------
https://chatgpt.com/codex/tasks/task_e_68af017d5e588330a8e9a4c35f37a49b