### PR TITLE
feat: expand homepage metadata

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -6,7 +6,43 @@ import HeadMeta from "@/components/HeadMeta";
 export default function HomePage() {
   return (
     <>
-      <HeadMeta title="Home" />
+      <HeadMeta
+        title="Zmiana wpisu w KRS bez stresu i błędów – zrobimy to za Ciebie | ZmianaKRS"
+        description="Profesjonalna i kompleksowa obsługa zmian w KRS – zdalnie, bez błędów i zwrotów. Zmiana zarządu, adresu, PKD, kapitału, umowy spółki. PRS/S24. Cennik i kontakt."
+        canonicalUrl="https://zmianakrs.pl/"
+        ogTitle="Zmiana wpisu w KRS bez stresu i błędów – zrobimy to za Ciebie | ZmianaKRS"
+        ogDescription="Profesjonalna i kompleksowa obsługa zmian w KRS – zdalnie, bez błędów i zwrotów. Zmiana zarządu, adresu, PKD, kapitału, umowy spółki. PRS/S24. Cennik i kontakt."
+        ogImage="https://zmianakrs.pl/images/krs-services.png"
+        locale="pl_PL"
+        siteName="ZmianaKRS"
+        robots="index,follow"
+        twitterCard="summary_large_image"
+        structuredData={{
+          "@context": "https://schema.org",
+          "@type": "ProfessionalService",
+          "name": "ZmianaKRS",
+          "url": "https://zmianakrs.pl/",
+          "serviceType": "Usługi prawne KRS",
+          "areaServed": "Polska",
+          "description":
+            "Profesjonalna i kompleksowa obsługa zmian w KRS – zdalnie, bez błędów i zwrotów. Zmiana zarządu, adresu, PKD, kapitału, umowy spółki. PRS/S24.",
+          "hasOfferCatalog": {
+            "@type": "OfferCatalog",
+            "name": "Usługi KRS",
+            "itemListElement": [
+              {
+                "@type": "Offer",
+                "itemOffered": {
+                  "@type": "Service",
+                  "name": "Zmiana wpisu w KRS",
+                  "description":
+                    "Kompleksowa obsługa wniosków o zmianę wpisu w KRS (PRS/S24) – przygotowanie dokumentów, złożenie wniosku, wsparcie do postanowienia sądu.",
+                },
+              },
+            ],
+          },
+        }}
+      />
       <Navbar />
       <main>
         <div className="relative isolate px-6 pt-14 lg:px-8">

--- a/components/HeadMeta.tsx
+++ b/components/HeadMeta.tsx
@@ -9,6 +9,10 @@ interface HeadMetaProps {
   ogTitle?: string
   ogDescription?: string
   ogImage?: string
+  locale?: string
+  siteName?: string
+  robots?: string
+  twitterCard?: string
   structuredData?: Record<string, any>
 }
 
@@ -20,6 +24,10 @@ export default function HeadMeta({
   ogTitle,
   ogDescription,
   ogImage,
+  locale,
+  siteName,
+  robots,
+  twitterCard,
   structuredData,
 }: HeadMetaProps) {
   return (
@@ -31,6 +39,10 @@ export default function HeadMeta({
       {ogTitle && <meta property="og:title" content={ogTitle} />}
       {ogDescription && <meta property="og:description" content={ogDescription} />}
       {ogImage && <meta property="og:image" content={ogImage} />}
+      {locale && <meta property="og:locale" content={locale} />}
+      {siteName && <meta property="og:site_name" content={siteName} />}
+      {robots && <meta name="robots" content={robots} />}
+      {twitterCard && <meta name="twitter:card" content={twitterCard} />}
       {structuredData && (
         <script
           type="application/ld+json"


### PR DESCRIPTION
## Summary
- add comprehensive SEO metadata to homepage
- enhance `HeadMeta` component with locale, robots, and Twitter props

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_SITE_URL=https://example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af39945c3c83309389d9fbfb6f5f85