### PR TITLE
Use inline background image for home page

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -53,7 +53,13 @@ export default function HomePage() {
     },
   };
   return (
-    <div className="min-h-screen bg-[url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')] bg-center bg-cover bg-no-repeat">
+    <div
+      className="min-h-screen bg-cover bg-center bg-no-repeat"
+      style={{
+        backgroundImage:
+          "url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
+      }}
+    >
       <Script
         id="home-jsonld"
         type="application/ld+json"
@@ -68,8 +74,7 @@ export default function HomePage() {
 
         {/* Sekcja: Profesjonalna obsługa wniosków o zmianę wpisu w KRS */}
         <section className="relative py-16 px-4 sm:px-6 lg:px-8">
-          <div className="max-w-4xl mx-auto">
-            <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg p-8 sm:p-12">
+          <div className="max-w-4xl mx-auto p-8 sm:p-12">
               <h2 className="text-2xl sm:text-3xl font-bold text-white mb-6 text-center">
                 Profesjonalna obsługa wniosków o zmianę wpisu w KRS
               </h2>
@@ -195,7 +200,6 @@ export default function HomePage() {
                   </Link>
                 </div>
               </div>
-            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- Wrap home page content with a full-screen div using inline background image styling
- Remove translucent overlay wrapper from service section to avoid redundant backgrounds

## Testing
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b0492bff788330bc8900ad97a1b716