### PR TITLE
fix: tweak hero background sizing

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -54,10 +54,11 @@ export default function HomePage() {
   };
   return (
     <div
-      className="min-h-screen bg-cover bg-center bg-no-repeat"
+      className="min-h-screen bg-center bg-no-repeat"
       style={{
         backgroundImage:
           "url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
+        backgroundSize: "auto 100%", // ewentualnie 'contain'
       }}
     >
       <Script


### PR DESCRIPTION
## Summary
- remove `bg-cover` from site home wrapper
- set inline `backgroundSize: "auto 100%"` for hero background image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b05ca63e8c83309bbdc7f5cfaa2f5d