### PR TITLE
feat: add about page background

### DIFF
--- a/app/(site)/o-nas/page.tsx
+++ b/app/(site)/o-nas/page.tsx
@@ -1,7 +1,16 @@
 export default function Page() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">O nas (placeholder)</h1>
-    </main>
+    <div
+      className="min-h-screen bg-center bg-no-repeat"
+      style={{
+        backgroundImage:
+          "url('/images/Solidne-fundamenty-prawne-eksperci-KRS-z-wieloletnim-doświadczeniem-w-obsłudze-wniosków-o-zmianę-wpi.webp')",
+        backgroundSize: "auto 100%",
+      }}
+    >
+      <main className="p-8">
+        <h1 className="text-2xl font-semibold">O nas (placeholder)</h1>
+      </main>
+    </div>
   );
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -54,10 +54,11 @@ export default function HomePage() {
   };
   return (
     <div
-      className="min-h-screen bg-cover bg-center bg-no-repeat"
+      className="min-h-screen bg-center bg-no-repeat"
       style={{
         backgroundImage:
           "url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
+        backgroundSize: "auto 100%", // ewentualnie 'contain'
       }}
     >
       <Script


### PR DESCRIPTION
## Summary
- add wood desk background to About page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b05ca63e8c83309bbdc7f5cfaa2f5d