### PR TITLE
Use cover background image for home page

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -54,11 +54,11 @@ export default function HomePage() {
   };
   return (
     <div
-      className="min-h-screen bg-center bg-no-repeat"
+      className="bg-center bg-no-repeat"
       style={{
         backgroundImage:
           "url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
-        backgroundSize: "auto 100%", // ewentualnie 'contain'
+        backgroundSize: "cover",
       }}
     >
       <Script


### PR DESCRIPTION
## Summary
- use `cover` for home page background image
- simplify wrapper classes to only center and disable repeat

## Testing
- `NEXT_PUBLIC_SITE_URL=https://example.com npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b06a5d897c8330bf2b73aa1174fe7e