### PR TITLE
Add background styling and page wrapper class

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,3 +4,15 @@
 
 /* --- Poniżej: CSS przeniesiony z poprzedniego projektu (index.css) --- */
 /* (Brak index.css — dodamy w następnym kroku) */
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background: url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center center / cover no-repeat fixed;
+  background-color: #0f172a;
+}
+.page-wrapper {
+  background: none !important;
+  min-height: 100vh;
+  position: relative;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pl">
-      <body>{children}</body>
+      <body className="page-wrapper">{children}</body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- add full-page background image and page wrapper styles
- apply `page-wrapper` class to `<body>` in layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b96c7b60d88330987cd80974ed2336