### PR TITLE
Refactor home page wrapper and overlay

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -53,32 +53,20 @@ export default function HomePage() {
     },
   };
   return (
-    <div
-      className="relative w-full aspect-[21/9] sm:aspect-[24/9] lg:aspect-[32/9] min-h-[60vh] overflow-hidden"
-      style={{
-        backgroundImage:
-          "url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
-        backgroundSize: "cover",
-      }}
-    >
-      <div
-        className="absolute inset-0 bg-no-repeat ![background-size:cover] ![background-position:center_30%] ![background-repeat:no-repeat]"
-        style={{
-          backgroundImage:
-            "url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
-        }}
-      />
-      <Script
-        id="home-jsonld"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(homeJsonLd) }}
-      />
+    <div className="page-wrapper relative w-full aspect-[21/9] sm:aspect-[24/9] lg:aspect-[32/9] min-h-[60vh] overflow-hidden">
+      <div className="absolute inset-0 bg-slate-900/60 pointer-events-none" />
+      <div className="relative z-10">
+        <Script
+          id="home-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(homeJsonLd) }}
+        />
 
-      <Navbar />
+        <Navbar />
 
-      <main>
-        <Hero />
-        <Features />
+        <main>
+          <Hero />
+          <Features />
 
         {/* Sekcja: Profesjonalna obsługa wniosków o zmianę wpisu w KRS */}
         <section className="relative py-16 px-4 sm:px-6 lg:px-8">
@@ -386,6 +374,7 @@ Oferujemy kompleksową pomoc w zmianie wpisu w Krajowym Rejestrze Sądowym (KRS)
       </main>
 
       <Footer />
+      </div>
     </div>
-    );
-  }
+  );
+}


### PR DESCRIPTION
## Summary
- refactor home page wrapper to use `page-wrapper` with overlay and layered content
- remove inline hero background styles and nested div

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b96d09301c8330be9776dc68eabde4