### PR TITLE
Fix page wrapper background handling

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -53,7 +53,7 @@ export default function HomePage() {
     },
   };
   return (
-    <div className="page-wrapper relative w-full aspect-[21/9] sm:aspect-[24/9] lg:aspect-[32/9] min-h-[60vh] overflow-hidden">
+    <div className="relative w-full aspect-[21/9] sm:aspect-[24/9] lg:aspect-[32/9] min-h-[60vh] overflow-hidden">
       <div className="absolute inset-0 bg-slate-900/60 pointer-events-none" />
       <div className="relative z-10">
         <Script

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,11 +8,5 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center center / cover no-repeat fixed;
   background-color: #0f172a;
-}
-.page-wrapper {
-  background: none !important;
-  min-height: 100vh;
-  position: relative;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,15 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pl">
-      <body className="page-wrapper">{children}</body>
+      <body
+        className="min-h-screen bg-cover bg-center bg-no-repeat bg-slate-900"
+        style={{
+          backgroundImage:
+            "url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
+        }}
+      >
+        {children}
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- remove `.page-wrapper` background override and unused class
- apply background image with `min-h-screen bg-cover bg-center bg-no-repeat` directly on `<body>`
- clean up home page wrapper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b96faa153883308c9f1d1eb02448bd