### PR TITLE
Use global background wrapper

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,13 @@
 body {
   margin: 0;
   padding: 0;
+}
+
+.page-wrapper {
   min-height: 100vh;
+  background-image: url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   background-color: #0f172a;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,13 +10,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pl">
-      <body
-        className="min-h-screen bg-cover bg-center bg-no-repeat bg-slate-900/60"
-        style={{
-          backgroundImage:
-            "url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
-        }}
-      >
+      <body className="page-wrapper">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- set `<body>` to use page-wrapper class
- move background image and sizing to global `.page-wrapper` styles

## Testing
- `NEXT_PUBLIC_SITE_URL=https://example.com npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b98b0ff330833088ee7821108aa478