### PR TITLE
refactor: use global page wrapper

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -53,13 +53,7 @@ export default function HomePage() {
     },
   };
   return (
-    <div
-      className="min-h-screen bg-cover bg-center bg-no-repeat"
-      style={{
-        backgroundImage:
-          "url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",
-      }}
-    >
+    <div className="page-wrapper">
       <div className="relative z-10">
         <Script
           id="home-jsonld"


### PR DESCRIPTION
## Summary
- remove inline background and background classes from home page wrapper
- use `page-wrapper` class to inherit global styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b98b247d6c8330bd33467d85f3ac2e