### PR TITLE
feat: add global background image

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,4 +9,10 @@ body {
   padding: 0;
   min-height: 100vh;
   background-color: #0f172a;
+  background: url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center center / cover no-repeat fixed;
+}
+
+.page-wrapper {
+  background: none !important;
+  min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- set a full-page background image on the `body`
- prevent nested backgrounds by clearing `.page-wrapper`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b98b2d74e48330aa83444b4e93e80c