### PR TITLE
Disable CSS optimization for Next.js build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,14 +3,19 @@ import { withContentlayer } from "next-contentlayer"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  images: { unoptimized: true },
-  experimental: { mdxRs: true, optimizeCss: false },
+  experimental: { mdxRs: true },
   async redirects() {
     return [
       { source: "/kontakt", destination: "/contact", permanent: true },
       { source: "/dla-ksiegowych", destination: "/ksiegowi", permanent: true },
     ]
   },
+}
+
+nextConfig.images = { unoptimized: true }
+nextConfig.experimental = {
+  ...nextConfig.experimental,
+  optimizeCss: false,
 }
 
 export default withContentlayer(nextConfig)


### PR DESCRIPTION
## Summary
- extend `nextConfig` with unoptimized images
- disable Next.js CSS optimization via `optimizeCss: false`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9914069a48330aa04e800516b7eeb