### PR TITLE
Use page wrapper for layout body

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // Use a page wrapper to apply global background styles
   return (
     <html lang="pl">
       <body className="page-wrapper">


### PR DESCRIPTION
## Summary
- clarify RootLayout with a comment and ensure body uses the global `page-wrapper` class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9911cf1208330bfc765d26256eb03