### PR TITLE
Remove body background styles

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,10 +8,9 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  // Use a page wrapper to apply global background styles
   return (
     <html lang="pl">
-      <body className="page-wrapper">
+      <body className="min-h-screen">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- remove extra background class from root layout body so page backgrounds show through

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b999b81938833084fa9f9a56074c17