### PR TITLE
Update hero section copy and refactor navbar to shadcn design

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="pl">
       <body
-        className="min-h-screen bg-cover bg-center bg-no-repeat bg-slate-900"
+        className="min-h-screen bg-cover bg-center bg-no-repeat bg-slate-900/60"
         style={{
           backgroundImage:
             "url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp')",

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -5,35 +5,38 @@ export default function Hero() {
   return (
     <section className="flex items-center justify-center text-center py-32 px-4 sm:py-40">
       <div className="max-w-4xl mx-auto text-white">
-        <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold leading-tight">
-          Zmiana wpisu w KRS bez stresu i zbędnych formalności
+        <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-6 sm:mb-8 leading-tight">
+          Zmiana wpisu w <span className="text-amber-400">KRS</span> bez stresu i błędów – zrobimy to za Ciebie
         </h1>
-        <p className="mt-6 text-lg sm:text-xl text-gray-200">
-          Kompleksowa obsługa wniosków o zmianę danych spółki – szybko,
-          bezpiecznie i online.
+        <p className="text-lg sm:text-xl md:text-2xl mb-6 sm:mb-8 text-gray-300 leading-relaxed text-justify">
+          Wiemy, jak uciążliwe, czasochłonne i frustrujące bywa samodzielne składanie wniosku o zmianę wpisu w KRS. Przez ostatnie lata pomogliśmy setkom klientów z całej Polski skutecznie przejść przez ten proces — bez błędów, bez zwrotów i bez nerwów.
+        </p>
+        <p className="text-lg sm:text-xl md:text-2xl mb-6 sm:mb-8 text-gray-300 leading-relaxed text-justify">
+          Nie ma znaczenia, gdzie mieszkasz — działamy zdalnie, profesjonalnie i kompleksowo. Od przygotowania dokumentów po złożenie kompletnego wniosku elektronicznego i uzyskanie prawomocnego wpisu.
         </p>
 
-        <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-          <Link
-            href="/cennik"
-            className="px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-md text-white font-medium"
-          >
-            Sprawdź cennik
-          </Link>
+        <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 justify-center items-center">
           <Link
             href="/uslugi"
-            className="px-8 py-3 bg-white/10 hover:bg-white/20 border border-white/20 rounded-md text-white font-medium"
+            className="w-full sm:w-auto bg-amber-800 hover:bg-amber-900 text-white px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-semibold rounded-lg transition-colors duration-150"
           >
-            Nasze usługi
+            Co robimy?
           </Link>
           <Link
-            href="/kontakt"
-            className="px-8 py-3 bg-white text-blue-600 hover:bg-gray-100 rounded-md font-medium"
+            href="/o-nas"
+            className="w-full sm:w-auto bg-amber-800 hover:bg-amber-900 text-white px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-semibold rounded-lg transition-colors duration-150"
           >
-            Skontaktuj się
+            Jak działamy?
+          </Link>
+          <Link
+            href="/cennik"
+            className="w-full sm:w-auto bg-amber-800 hover:bg-amber-900 text-white px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-semibold rounded-lg transition-colors duration-150"
+          >
+            Ile to kosztuje?
           </Link>
         </div>
       </div>
     </section>
   )
 }
+

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,58 +1,165 @@
-"use client";
+'use client';
 
-import React from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Menu, Phone, Mail } from "lucide-react";
 
 export default function Navbar() {
+  const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
 
-  const navItems = [
-    { href: "/", label: "Strona główna" },
-    { href: "/uslugi", label: "Usługi" },
-    { href: "/cennik", label: "Cennik" },
-    { href: "/blog", label: "Blog" },
-    { href: "/kontakt", label: "Kontakt" },
-  ];
-
-  const isActive = (href: string) =>
-    href === "/" ? pathname === "/" : pathname.startsWith(href);
+  const NavLinks = ({ mobile = false }) => (
+    <div className={mobile ? "flex flex-col space-y-4" : "flex items-center space-x-6"}>
+      <Link href="/">
+        <span
+          className={`${
+            pathname === '/'
+              ? 'bg-amber-800 text-white px-3 py-1 rounded'
+              : 'text-muted-foreground hover:text-amber-800'
+          } transition-colors font-medium cursor-pointer`}
+        >
+          Strona główna
+        </span>
+      </Link>
+      <Link href="/o-nas">
+        <span
+          className={`${
+            pathname === '/o-nas'
+              ? 'bg-amber-800 text-white px-3 py-1 rounded'
+              : 'text-muted-foreground hover:text-amber-800'
+          } transition-colors font-medium cursor-pointer`}
+        >
+          O nas
+        </span>
+      </Link>
+      <Link href="/uslugi">
+        <span
+          className={`${
+            pathname === '/uslugi'
+              ? 'bg-amber-800 text-white px-3 py-1 rounded'
+              : 'text-muted-foreground hover:text-amber-800'
+          } transition-colors font-medium cursor-pointer`}
+        >
+          Usługi
+        </span>
+      </Link>
+      <Link href="/cennik">
+        <span
+          className={`${
+            pathname === '/cennik'
+              ? 'bg-amber-800 text-white px-3 py-1 rounded'
+              : 'text-muted-foreground hover:text-amber-800'
+          } transition-colors font-medium cursor-pointer`}
+        >
+          Cennik
+        </span>
+      </Link>
+      <Link href="/blog">
+        <span
+          className={`${
+            pathname === '/blog' || pathname.startsWith('/blog/')
+              ? 'bg-amber-800 text-white px-3 py-1 rounded'
+              : 'text-muted-foreground hover:text-amber-800'
+          } transition-colors font-medium cursor-pointer`}
+        >
+          Blog
+        </span>
+      </Link>
+      <Link href="/ksiegowi">
+        <span
+          className={`${
+            pathname === '/ksiegowi'
+              ? 'bg-amber-800 text-white px-3 py-1 rounded'
+              : 'text-muted-foreground hover:text-amber-800'
+          } transition-colors font-medium cursor-pointer`}
+        >
+          Dla Księgowych
+        </span>
+      </Link>
+      <Link href="/kontakt">
+        <span
+          className={`${
+            pathname === '/kontakt'
+              ? 'bg-amber-800 text-white px-3 py-1 rounded'
+              : 'text-muted-foreground hover:text-amber-800'
+          } transition-colors font-medium cursor-pointer`}
+        >
+          Kontakt
+        </span>
+      </Link>
+    </div>
+  );
 
   return (
-    <header className="w-full">
-      <div className="bg-gray-900 text-gray-100 text-sm">
-        <div className="max-w-6xl mx-auto flex justify-between items-center px-4 py-2">
-          <div className="flex gap-4">
-            <a href="tel:572234779" className="hover:text-amber-400">
-              {"572\u202f234\u202f779"}
+    <header className="bg-background shadow-sm border-b border-border sticky top-0 z-50">
+      <nav
+        className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"
+        role="navigation"
+        aria-label="Nawigacja główna"
+      >
+        <div className="flex justify-between items-center h-16">
+          {/* Contact info - left side desktop */}
+          <div className="hidden lg:flex items-center space-x-6 text-base font-bold text-amber-800">
+            <div className="flex items-center space-x-2">
+              <Phone className="h-5 w-5" />
+              <a
+                href="tel:+48572234779"
+                className="hover:text-amber-600 transition-colors"
+              >
+                572 234 779
+              </a>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Mail className="h-5 w-5" />
+              <a
+                href="mailto:biuro@zmianakrs.pl"
+                className="hover:text-amber-600 transition-colors"
+              >
+                biuro@zmianakrs.pl
+              </a>
+            </div>
+          </div>
+
+          {/* Contact info - mobile */}
+          <div className="flex md:hidden items-center space-x-4 text-amber-800">
+            <a
+              href="tel:+48572234779"
+              className="hover:text-amber-600 transition-colors"
+            >
+              <Phone className="h-5 w-5" />
             </a>
             <a
-              href="mailto:kontakt@zmianakrs.pl"
-              className="hover:text-amber-400"
+              href="mailto:biuro@zmianakrs.pl"
+              className="hover:text-amber-600 transition-colors"
             >
-              kontakt@zmianakrs.pl
+              <Mail className="h-5 w-5" />
             </a>
           </div>
-          <nav className="hidden sm:block">
-            <ul className="flex gap-6">
-              {navItems.map((item) => (
-                <li key={item.href}>
-                  <Link
-                    href={item.href}
-                    className={`inline-block px-3 py-2 hover:text-amber-400 ${
-                      isActive(item.href)
-                        ? "text-amber-400 font-semibold border-b-2 border-amber-400"
-                        : "text-gray-300"
-                    }`}
-                  >
-                    {item.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </nav>
+
+          {/* Desktop Navigation */}
+          <div className="hidden md:flex items-center space-x-4">
+            <NavLinks />
+          </div>
+
+          {/* Mobile Navigation */}
+          <Sheet open={isOpen} onOpenChange={setIsOpen}>
+            <SheetTrigger asChild className="md:hidden">
+              <Button variant="ghost" size="icon">
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-[250px]">
+              <div className="mt-8">
+                <NavLinks mobile />
+              </div>
+            </SheetContent>
+          </Sheet>
         </div>
-      </div>
+      </nav>
     </header>
   );
 }
+


### PR DESCRIPTION
## Summary
- revert layout overlay to bg-slate-900/60 for non-transparent background
- refresh Hero content with new copy, paragraphs, and CTA links
- replace navbar with shadcn UI version featuring contact links and mobile sheet menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68b055cc082c83309a5fcd26fc0e7394