### PR TITLE
fix: keep blog nav item active on post pages

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -16,7 +16,11 @@ export default function Navbar() {
   ];
 
   const isActive = (href: string) =>
-    href === "/" ? pathname === "/" : pathname.startsWith(href);
+    href === "/"
+      ? pathname === "/"
+      : href === "/blog"
+      ? pathname === "/blog" || pathname.startsWith("/blog/")
+      : pathname.startsWith(href);
 
   return (
     <header className="w-full">


### PR DESCRIPTION
## Summary
- ensure Blog menu stays highlighted when viewing individual blog posts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04d1ddc9483309a355c25372df3e8