### PR TITLE
Centralize global background overlay

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -25,14 +25,13 @@ export const metadata: Metadata = {
 
 export default function HomePage() {
   return (
-    <div className="page-wrapper">
-      <div className="fixed inset-0 bg-slate-900/60 -z-10"></div>
+    <>
       <Navbar />
       <main>
         <Hero />
         <Features />
       </main>
       <Footer />
-    </div>
+    </>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,8 +11,3 @@ body {
   background: url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center center / cover no-repeat fixed;
   background-color: #0f172a;
 }
-
-.page-wrapper {
-  background: none !important;
-  min-height: 100vh;
-}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,8 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pl">
-  <body className="min-h-screen">
+      <body className="min-h-screen relative">
+        <div className="fixed inset-0 bg-slate-900/60 -z-10" />
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Move dark overlay to `app/layout.tsx` so it applies globally
- Remove duplicate background overlay and wrapper from home page
- Clean up unused `.page-wrapper` CSS

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05163f6f08330ae71deda8451b98d