### PR TITLE
refactor: centralize wood background styling

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -25,13 +25,14 @@ export const metadata: Metadata = {
 
 export default function HomePage() {
   return (
-    <>
+    <div className="relative">
+      <div className="fixed inset-0 bg-slate-900/60 -z-10" />
       <Navbar />
       <main>
         <Hero />
         <Features />
       </main>
       <Footer />
-    </>
+    </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,5 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: url('/images/usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center center / cover no-repeat fixed;
-  background-color: #0f172a;
+  background: url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center/cover no-repeat fixed;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,8 +10,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pl">
-      <body className="min-h-screen relative">
-        <div className="fixed inset-0 bg-slate-900/60 -z-10" />
+      <body className="min-h-screen">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- remove background classes from layout and page
- define wood texture background in global CSS
- keep home page overlay wrapper only

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c053c5be448330af1c29fcf8c00752