### PR TITLE
feat: adjust hero headline line break

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -7,7 +7,9 @@ export default function Hero() {
     <section className="flex items-center justify-center text-center py-32 px-4 sm:py-40 bg-transparent">
       <div className="max-w-4xl mx-auto text-white">
         <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-6 sm:mb-8 leading-tight">
-          Zmiana wpisu w <span className="text-amber-400">KRS</span> bez stresu i błędów – zrobimy to za Ciebie
+          Zmiana wpisu w <span className="text-amber-400">KRS</span>{' '}
+          <br className="hidden md:block" />
+          bez stresu i błędów – zrobimy to za Ciebie
         </h1>
         <p className="text-lg sm:text-xl md:text-2xl mb-6 sm:mb-8 text-gray-300 leading-relaxed text-justify">
           Wiemy, jak uciążliwe, czasochłonne i frustrujące bywa samodzielne składanie wniosku o zmianę wpisu w KRS. Przez ostatnie lata pomogliśmy setkom klientów z całej Polski skutecznie przejść przez ten proces — bez błędów, bez zwrotów i bez nerwów.


### PR DESCRIPTION
## Summary
- add responsive line break after "KRS" in hero headline for clearer layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1282de60883309788d10663a98490