### PR TITLE
feat: lighten navbar background color

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -24,7 +24,7 @@ export default function Navbar() {
 
   return (
     <header className="w-full">
-      <div className="bg-gray-800 text-gray-100 text-sm">
+      <div className="bg-gray-700 text-gray-100 text-sm">
         <div className="w-4/5 max-w-7xl mx-auto flex justify-between items-center px-4 py-4">
           <div className="flex gap-4">
             <a


### PR DESCRIPTION
## Summary
- lighten navbar header by changing bg-gray-800 to bg-gray-700

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c13b60258c8330aad990d3cb3d81cf