### PR TITLE
feat: add color variables to tailwind

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,12 @@ const config: Config = {
   theme: {
     extend: {
       screens: { xs: "475px" },
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        muted: 'hsl(var(--muted-foreground))',
+        border: 'hsl(var(--border))',
+      },
     },
   },
   plugins: [require('@tailwindcss/typography')],


### PR DESCRIPTION
## Summary
- add background, foreground, muted, and border colors to Tailwind config

## Testing
- `npm test`
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c14247792c8330bcf7f9f06446835e