### PR TITLE
feat: add background and muted color tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,8 +5,15 @@
 :root {
   --background: 40 20% 95%;
   --foreground: 20 60% 15%;
-  --muted-foreground: 25 45% 30%;
+  --muted: 25 45% 30%;
   --border: 35 25% 75%;
+}
+
+.dark {
+  --background: 20 60% 15%;
+  --foreground: 40 20% 95%;
+  --muted: 25 45% 65%;
+  --border: 35 25% 35%;
 }
 
 /* --- Poniżej: CSS przeniesiony z poprzedniego projektu (index.css) --- */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
       colors: {
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
-        muted: 'hsl(var(--muted-foreground))',
+        muted: 'hsl(var(--muted))',
         border: 'hsl(var(--border))',
       },
     },


### PR DESCRIPTION
## Summary
- extend Tailwind theme colors for background, foreground, and muted using CSS variables
- define matching CSS variable palette with dark mode overrides

## Testing
- `npm test`
- `npm run lint`
- `NEXT_PUBLIC_SITE_URL=https://example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c145ada71083309346b9209fa37ac8