### PR TITLE
Add queryFn to services query and expose API

### DIFF
--- a/app/(site)/uslugi/page.tsx
+++ b/app/(site)/uslugi/page.tsx
@@ -1,7 +1,38 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+interface Service {
+  id: number;
+  name: string;
+  description: string;
+}
+
 export default function Page() {
+  const { data: services, isLoading } = useQuery<Service[]>({
+    queryKey: ["/api/services"],
+    queryFn: () => fetch("/api/services").then((res) => res.json()),
+  });
+
+  if (isLoading) {
+    return (
+      <main className="p-8">
+        <h1 className="text-2xl font-semibold">Ładowanie...</h1>
+      </main>
+    );
+  }
+
   return (
     <main className="p-8">
-      <h1 className="text-2xl font-semibold">Usługi (placeholder)</h1>
+      <h1 className="text-2xl font-semibold mb-4">Usługi</h1>
+      <ul className="space-y-4">
+        {services?.map((service) => (
+          <li key={service.id}>
+            <h2 className="text-xl font-medium">{service.name}</h2>
+            <p className="text-sm text-gray-600">{service.description}</p>
+          </li>
+        ))}
+      </ul>
     </main>
   );
 }

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+interface Service {
+  id: number;
+  name: string;
+  description: string;
+}
+
+const services: Service[] = [
+  {
+    id: 1,
+    name: "Rejestracja spółki",
+    description: "Pomoc w rejestracji spółki w KRS.",
+  },
+  {
+    id: 2,
+    name: "Zmiany w KRS",
+    description: "Obsługa wniosków o zmianę w KRS.",
+  },
+];
+
+export async function GET() {
+  return NextResponse.json(services);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import Providers from './providers'
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://moja-strona-nextjs.vercel.app'),
@@ -11,7 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="pl">
       <body className="min-h-screen">
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- fetch services from new API using react-query with queryFn
- wrap layout with QueryClientProvider
- add simple /api/services endpoint

## Testing
- `npm test`
- `npm run lint`
- `npm run dev` (curl http://localhost:3000/api/services)


------
https://chatgpt.com/codex/tasks/task_e_68c7c99926d883308ac7090b67f6264c