### PR TITLE
Fix Navbar/Footer imports for about page

### DIFF
--- a/app/(site)/o-nas/page.tsx
+++ b/app/(site)/o-nas/page.tsx
@@ -1,3 +1,6 @@
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+
 export default function Page() {
   return (
     <div
@@ -8,9 +11,11 @@ export default function Page() {
         backgroundSize: "auto 100%",
       }}
     >
+      <Navbar />
       <main className="p-8">
         <h1 className="text-2xl font-semibold">O nas (placeholder)</h1>
       </main>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use capitalized Navbar and Footer imports in o-nas page
- include Navbar and Footer components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d0f364808330aedfb560c53bdef0