### PR TITLE
feat: add about page background class

### DIFF
--- a/app/(site)/o-nas/page.tsx
+++ b/app/(site)/o-nas/page.tsx
@@ -1,13 +1,7 @@
 export default function Page() {
   return (
-    <div
-      className="min-h-screen bg-center bg-no-repeat"
-      style={{
-        backgroundImage:
-          "url('/images/Solidne-fundamenty-prawne-eksperci-KRS-z-wieloletnim-doświadczeniem-w-obsłudze-wniosków-o-zmianę-wpi.webp')",
-        backgroundSize: "auto 100%",
-      }}
-    >
+    <div className="about-background relative min-h-screen">
+      <div className="absolute inset-0 bg-slate-900/60 -z-10" />
       <main className="p-8">
         <h1 className="text-2xl font-semibold">O nas (placeholder)</h1>
       </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,7 @@ body {
   min-height: 100vh;
   background: url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center/cover no-repeat fixed;
 }
+
+.about-background {
+  background: url('/images/solidne-fundamenty-prawne-eksperci-krs-doswiadczenie-wnioski-zmiana-wpisu.webp') center/cover no-repeat fixed;
+}


### PR DESCRIPTION
## Summary
- add reusable `about-background` class with fixed background image
- apply `about-background` and overlay to about page layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d0f84abc833090a5d6e568d4b97a