### PR TITLE
Use array mapping for trust cards

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
 import Features from "@/components/Features";
+import Trust from "@/components/Trust";
 import Footer from "@/components/Footer";
 
 export const metadata: Metadata = {
@@ -31,6 +32,7 @@ export default function HomePage() {
       <main>
         <Hero />
         <Features />
+        <Trust />
       </main>
       <Footer />
     </div>

--- a/components/Trust.tsx
+++ b/components/Trust.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Award, Shield, Clock } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+
+const trustCards = [
+  {
+    icon: Award,
+    title: 'Ponad 10 lat doświadczenia',
+    text: 'Zaufały nam setki przedsiębiorców z całej Polski.',
+  },
+  {
+    icon: Shield,
+    title: 'Bezpieczeństwo dokumentów',
+    text: 'Dbamy o poufność i zgodność z przepisami.',
+  },
+  {
+    icon: Clock,
+    title: 'Terminowość',
+    text: 'Działamy szybko i sprawnie, pilnując terminów.',
+  },
+]
+
+export default function Trust() {
+  return (
+    <section className="py-20">
+      <div className="max-w-6xl mx-auto px-4 grid md:grid-cols-3 gap-8">
+        {trustCards.map(({ icon: Icon, title, text }) => (
+          <Card key={title} className="text-center">
+            <Icon className="mx-auto mb-4 h-12 w-12 text-amber-600" />
+            <h3 className="font-semibold mb-2">{title}</h3>
+            <p className="text-sm text-gray-600">{text}</p>
+          </Card>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className = '', ...props }: CardProps) {
+  return (
+    <div
+      className={`rounded-lg border bg-white p-6 shadow-sm ${className}`}
+      {...props}
+    />
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-query": "^5.60.5",
         "contentlayer": "^0.3.4",
         "drizzle-orm": "^0.39.1",
+        "lucide-react": "^0.544.0",
         "next": "latest",
         "next-contentlayer": "^0.3.4",
         "nodemailer": "^7.0.3",
@@ -6490,6 +6491,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/markdown-extensions": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.60.5",
     "contentlayer": "^0.3.4",
     "drizzle-orm": "^0.39.1",
+    "lucide-react": "^0.544.0",
     "next": "latest",
     "next-contentlayer": "^0.3.4",
     "nodemailer": "^7.0.3",


### PR DESCRIPTION
## Summary
- add lucide-react for icons
- create Card component
- map trust card data to Card components on home page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d0fed2b0833083decd32b437273d