### PR TITLE
Use CSS background for homepage hero

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -4,6 +4,7 @@ import Hero from "@/components/Hero";
 import Features from "@/components/Features";
 import Trust from "@/components/Trust";
 import Footer from "@/components/Footer";
+import professionalWaitingRoomImage from "@/public/images/Profesjonalna-poczekalnia-prawnicza-z-eleganckimi-krzeslami-atmosfera-zaufania.webp";
 
 export const metadata: Metadata = {
   title:
@@ -27,7 +28,14 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <div className="relative">
-      <div className="absolute inset-0 bg-slate-900/60 -z-10" />
+      <div
+        className="fixed inset-0 -z-10 bg-slate-900/75"
+        style={{
+          backgroundImage: `url(${professionalWaitingRoomImage.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
       <Navbar />
       <main>
         <Hero />

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,7 +22,6 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: url('/images/nowoczesne-biuro-profesjonalne-usługi-KRS-obsługa-wniosków-o-zmianę-wpisu-w-KRS.webp') center/cover no-repeat fixed;
 }
 
 .about-background {


### PR DESCRIPTION
## Summary
- replace img-based homepage background with CSS style on fixed wrapper
- drop global body background image

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: NEXT_PUBLIC_SITE_URL env variable is not set; markdown-wasm missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d8c638c88330bb75a68d07da81f0