### PR TITLE
Implement marketing page layouts and SEO metadata

### DIFF
--- a/app/(site)/cennik/page.tsx
+++ b/app/(site)/cennik/page.tsx
@@ -1,14 +1,256 @@
-import Navbar from "@/components/Navbar";
-import Footer from "@/components/Footer";
+import type { Metadata } from "next"
+import Script from "next/script"
 
-export default function Page() {
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import professionalWaitingRoomImage from "@/public/images/Profesjonalna-poczekalnia-prawnicza-z-eleganckimi-krzeslami-atmosfera-zaufania.webp"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
+
+const pricingTiers = [
+  {
+    name: "Start",
+    price: "od 590 zł netto",
+    badge: "Najczęściej wybierany",
+    description:
+      "Dla spółek przygotowujących pierwszy wniosek o zmianę wpisu lub prostą aktualizację danych w rejestrze.",
+    includes: [
+      "Analiza dokumentów i wskazanie wymaganych uchwał",
+      "Przygotowanie kompletnego wniosku S24 lub Portalu Rejestrów Sądowych",
+      "Weryfikacja podpisów elektronicznych i wysyłka do KRS",
+    ],
+  },
+  {
+    name: "Rozwój",
+    price: "od 890 zł netto",
+    description:
+      "Pakiet dla spółek przeprowadzających złożone zmiany – zmiana umowy, rozszerzenie PKD, powołanie nowych organów.",
+    includes: [
+      "Opracowanie projektów uchwał i załączników",
+      "Koordynacja podpisów wspólników oraz reprezentacji przed notariuszem",
+      "Monitorowanie statusu sprawy i wsparcie przy uzupełnieniach",
+    ],
+  },
+  {
+    name: "Premium",
+    price: "wycena indywidualna",
+    description:
+      "Kompleksowa obsługa zmian strukturalnych, reorganizacji grup kapitałowych i projektów wymagających reprezentacji przed sądem.",
+    includes: [
+      "Strategia zmian i harmonogram prac z dedykowanym opiekunem",
+      "Przygotowanie dokumentów do zgłoszeń w urzędach powiązanych (US, GUS, ZUS)",
+      "Stały dostęp do konsultacji prawno-księgowych oraz raportowanie postępów",
+    ],
+  },
+]
+
+const faqs = [
+  {
+    title: "Co wpływa na ostateczną wycenę usługi?",
+    content:
+      "Na cenę wpływa liczba koniecznych uchwał, złożoność zmian w umowie spółki, konieczność udziału notariusza oraz to, czy przygotowujemy dokumenty do dodatkowych zgłoszeń w urzędach. Przed rozpoczęciem współpracy otrzymujesz kosztorys i harmonogram prac, abyś dokładnie wiedział, ile zapłacisz i na jakim etapie znajdują się działania.",
+    pageId: "cennik-faq-1",
+  },
+  {
+    title: "Czy opłata sądowa jest wliczona w cenę?",
+    content:
+      "Opłaty sądowe oraz za ogłoszenie w Monitorze Sądowym i Gospodarczym są niezależne od naszego wynagrodzenia. Na życzenie możemy opłacić je w Twoim imieniu, aby przyspieszyć procedurę — koszt przelewamy dokładnie w wysokości wynikającej z przepisów.",
+    pageId: "cennik-faq-2",
+  },
+  {
+    title: "Czy oferujecie abonament dla stałych klientów?",
+    content:
+      "Tak. Dla biur rachunkowych, kancelarii i spółek, które regularnie zgłaszają zmiany w KRS, przygotowaliśmy abonament z ryczałtowym rozliczeniem miesięcznym oraz priorytetową obsługą zgłoszeń w trybie ekspresowym.",
+    pageId: "cennik-faq-3",
+  },
+]
+
+const pageUrl = `${siteUrl}/cennik`
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Cennik usług zmiany wpisu w KRS",
+  url: pageUrl,
+  provider: organizationSchema,
+  areaServed: {
+    "@type": "Country",
+    name: "Polska",
+  },
+  offers: pricingTiers.map((tier) => {
+    const numericPrice = tier.price.match(/\d+/g)?.join("")
+
+    return {
+      "@type": "Offer",
+      name: tier.name,
+      ...(numericPrice
+        ? {
+            priceSpecification: {
+              "@type": "PriceSpecification",
+              price: numericPrice,
+              priceCurrency: "PLN",
+            },
+          }
+        : {}),
+      description: tier.description,
+      availability: "https://schema.org/InStock",
+    }
+  }),
+}
+
+export const metadata: Metadata = {
+  title: "Cennik obsługi zmian w KRS | ZmianaKRS",
+  description:
+    "Poznaj przejrzysty cennik obsługi zmian w KRS. Pakiety Start, Rozwój i Premium dopasowane do etapu rozwoju Twojej spółki.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "Cennik obsługi zmian w KRS | ZmianaKRS",
+    description:
+      "Porównaj pakiety obsługi wniosków do KRS i wybierz zakres wsparcia dopasowany do Twojej spółki.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "Cennik usług KRS",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Cennik obsługi zmian w KRS",
+    description:
+      "Przejrzyste pakiety obsługi zmian w Krajowym Rejestrze Sądowym dla firm i biur rachunkowych.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
+
+export default function PricingPage() {
   return (
-    <div>
+    <div className="relative min-h-screen text-white">
+      <Script id="cennik-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${professionalWaitingRoomImage.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
       <Navbar />
-      <main className="p-8">
-        <h1 className="text-2xl font-semibold">Cennik (placeholder)</h1>
+
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section className="mx-auto max-w-3xl text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Oferta</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            Przejrzysty cennik obsługi zmian w KRS
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Wybierz pakiet, który najlepiej odpowiada zakresowi planowanych zmian. Każde zlecenie rozpoczynamy od
+            konsultacji oraz przygotowania harmonogramu działań, aby cały proces był przewidywalny.
+          </p>
+        </section>
+
+        <section className="grid gap-8 md:grid-cols-3">
+          {pricingTiers.map((tier) => (
+            <article
+              key={tier.name}
+              className="flex flex-col gap-6 rounded-2xl bg-slate-900/70 p-8 backdrop-blur"
+            >
+              <div className="space-y-3">
+                <h2 className="text-2xl font-semibold text-white">{tier.name}</h2>
+                {tier.badge ? (
+                  <span className="inline-block rounded-full bg-amber-500/20 px-3 py-1 text-xs font-medium text-amber-200">
+                    {tier.badge}
+                  </span>
+                ) : null}
+                <p className="text-sm uppercase tracking-widest text-amber-300">{tier.price}</p>
+                <p className="text-sm text-slate-300">{tier.description}</p>
+              </div>
+              <ul className="space-y-3 text-sm text-slate-200">
+                {tier.includes.map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-auto">
+                <a
+                  href="/kontakt"
+                  className="inline-flex items-center justify-center rounded-lg bg-amber-600 px-5 py-3 text-sm font-semibold text-slate-900 transition hover:bg-amber-500"
+                >
+                  Zapytaj o termin
+                </a>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Co zawiera przygotowanie wniosku?</h2>
+            <p className="text-slate-200">
+              Pracujemy w modelu projektowym. Wyznaczamy dedykowanego opiekuna, który prowadzi Cię przez każdy etap zmiany –
+              od analizy dokumentów, przez przygotowanie uchwał, aż po monitorowanie decyzji sądu. Dokumenty przygotowujemy w
+              oparciu o aktualne wzory ministerialne oraz orzecznictwo KRS.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>
+                  Wsparcie w uzyskaniu podpisów elektronicznych, w tym organizacja podpisów zdalnych dla wspólników przebywających
+                  poza Polską.
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>
+                  Pełna archiwizacja i przekazanie kompletnej dokumentacji w wersji elektronicznej oraz – na życzenie – papierowej.
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>
+                  Proaktywna komunikacja z sądem rejestrowym i informowanie Cię o każdym statusie sprawy.
+                </span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {faqs.map((faq) => (
+            <SEOExpandableSection key={faq.pageId} title={faq.title} content={faq.content} pageId={faq.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Porozmawiajmy o Twoim projekcie</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            Opowiedz nam o planowanych zmianach w spółce. W ciągu jednego dnia roboczego przygotujemy harmonogram, listę
+            wymaganych dokumentów i kosztorys.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="/kontakt"
+          >
+            Umów konsultację
+          </a>
+        </section>
       </main>
+
       <Footer />
     </div>
-  );
+  )
 }

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -1,7 +1,192 @@
-export default function Page() {
+import type { Metadata } from "next"
+import Script from "next/script"
+
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import contactBackground from "@/public/images/contact-bg.webp"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
+
+const pageUrl = `${siteUrl}/contact`
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "ContactPage",
+  name: "Kontakt z zespołem ZmianaKRS",
+  url: pageUrl,
+  publisher: organizationSchema,
+  contactPoint: {
+    "@type": "ContactPoint",
+    telephone: "+48572234779",
+    email: "kontakt@zmianakrs.pl",
+    contactType: "customer service",
+    areaServed: "PL",
+    availableLanguage: ["pl-PL"],
+  },
+}
+
+export const metadata: Metadata = {
+  title: "Kontakt | ZmianaKRS",
+  description:
+    "Skontaktuj się z zespołem ZmianaKRS. Konsultacja telefoniczna, spotkanie online lub wsparcie mailowe w zakresie zmian w KRS.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "Kontakt | ZmianaKRS",
+    description:
+      "Porozmawiaj z ekspertem ds. zmian w KRS. Telefon, e-mail oraz formularz konsultacyjny dostępny w jednym miejscu.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "Kontakt z zespołem ZmianaKRS",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Kontakt ZmianaKRS",
+    description: "Zarezerwuj konsultację i dowiedz się, jak możemy wesprzeć Twoją spółkę przy zmianach w KRS.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
+
+const faqs = [
+  {
+    title: "Jak wygląda pierwsza konsultacja?",
+    content:
+      "Rozmawiamy o zakresie zmian w spółce, analizujemy aktualny wpis w KRS i wskazujemy wymagane dokumenty. Po spotkaniu otrzymujesz e-mail z podsumowaniem i propozycją harmonogramu.",
+    pageId: "contact-faq-1",
+  },
+  {
+    title: "Czy mogę przekazać dokumenty online?",
+    content:
+      "Tak. Korzystamy z bezpiecznego repozytorium plików. Wystarczy, że prześlesz skany podpisanych uchwał i pełnomocnictw, a resztą zajmuje się nasz zespół.",
+    pageId: "contact-faq-2",
+  },
+]
+
+const contactCards = [
+  {
+    title: "Zadzwoń",
+    value: "+48 572 234 779",
+    href: "tel:+48572234779",
+    helper: "Poniedziałek – piątek, 8:00-18:00",
+  },
+  {
+    title: "Napisz",
+    value: "kontakt@zmianakrs.pl",
+    href: "mailto:kontakt@zmianakrs.pl",
+    helper: "Odpowiadamy w ciągu jednego dnia roboczego",
+  },
+  {
+    title: "Umów spotkanie",
+    value: "Konsultacja online",
+    href: "/uslugi",
+    helper: "Zarezerwuj termin i poznaj rekomendowany zakres prac",
+  },
+]
+
+export default function ContactPage() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">Kontakt (placeholder)</h1>
-    </main>
-  );
+    <div className="relative min-h-screen text-white">
+      <Script id="contact-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${contactBackground.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <Navbar />
+
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section className="text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Skontaktuj się z nami</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            Porozmawiajmy o Twojej zmianie w KRS
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Nasi specjaliści pomagają w zmianach zarządu, aktualizacjach umowy spółki, reorganizacji udziałów i wielu innych
+            procesach rejestrowych. Wybierz dogodną formę kontaktu, aby uzyskać indywidualną ofertę.
+          </p>
+        </section>
+
+        <section className="grid gap-8 md:grid-cols-3">
+          {contactCards.map((card) => (
+            <article
+              key={card.title}
+              className="flex flex-col items-center gap-2 rounded-2xl bg-slate-900/70 px-6 py-8 text-center backdrop-blur"
+            >
+              <h2 className="text-xl font-semibold text-white">{card.title}</h2>
+              <a
+                href={card.href}
+                className="text-lg font-medium text-amber-200 transition hover:text-amber-100"
+              >
+                {card.value}
+              </a>
+              <p className="text-sm text-slate-300">{card.helper}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 text-left backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Dlaczego warto działać z nami?</h2>
+            <p className="text-slate-200">
+              Zapewniamy wsparcie merytoryczne oraz technologiczne – przygotujemy dokumenty, zbierzemy podpisy, a także
+              przeprowadzimy Cię przez elektroniczne złożenie wniosku. Jesteśmy do dyspozycji na każdym etapie postępowania.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Dedykowany opiekun projektu dostępny telefonicznie i mailowo.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Transparentne rozliczenie – wiesz, za co płacisz i jakie dokumenty przygotowujemy.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Stały monitoring statusu sprawy i informowanie o kolejnych krokach.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {faqs.map((faq) => (
+            <SEOExpandableSection key={faq.pageId} title={faq.title} content={faq.content} pageId={faq.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Zarezerwuj 30-minutową konsultację</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            W trakcie spotkania omówimy dokumenty, terminy i koszty. Jeśli zdecydujesz się na współpracę, przygotujemy pełną
+            checklistę zadań.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="/cennik"
+          >
+            Sprawdź dostępne pakiety
+          </a>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
 }

--- a/app/(site)/ksiegowi/page.tsx
+++ b/app/(site)/ksiegowi/page.tsx
@@ -1,7 +1,178 @@
-export default function Page() {
+import type { Metadata } from "next"
+import Script from "next/script"
+
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import accountantsBackground from "@/public/images/profesjonalna-obsluga-zmian-krs-dla-biur-rachunkowych.webp"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
+
+const pageUrl = `${siteUrl}/ksiegowi`
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Obsługa zmian KRS dla biur rachunkowych",
+  url: pageUrl,
+  provider: organizationSchema,
+  serviceType: "White-label KRS filing",
+  audience: {
+    "@type": "Audience",
+    audienceType: "Biura rachunkowe i kancelarie",
+  },
+}
+
+export const metadata: Metadata = {
+  title: "Obsługa zmian KRS dla księgowych | ZmianaKRS",
+  description:
+    "Zyskaj partnera do obsługi wniosków KRS. White-label dla biur rachunkowych, raportowanie postępów i wsparcie ekspertów.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "Obsługa zmian KRS dla księgowych | ZmianaKRS",
+    description:
+      "Przekaż przygotowanie dokumentów i składanie wniosków KRS zespołowi ZmianaKRS. Transparentne zasady współpracy B2B.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "Obsługa zmian KRS dla biur rachunkowych",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Wsparcie KRS dla księgowych",
+    description:
+      "Deleguj przygotowanie i złożenie wniosków KRS ekspertom. White-label dla biur rachunkowych i kancelarii.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
+
+const benefits = [
+  {
+    title: "White-label",
+    description:
+      "Pracujemy w tle – komunikację z klientem możesz prowadzić pod własną marką, a my przygotujemy komplet dokumentów do podpisu.",
+  },
+  {
+    title: "Priorytetowe terminy",
+    description:
+      "Rezerwujemy czas w kalendarzu zespołu na zgłoszenia Twoich klientów. W pilnych sprawach rozpoczynamy działania w 24h.",
+  },
+  {
+    title: "Statusy w czasie rzeczywistym",
+    description:
+      "Otrzymujesz dostęp do panelu z listą spraw oraz historią komunikacji z sądem. Możesz udostępnić statusy swoim klientom.",
+  },
+]
+
+const faqs = [
+  {
+    title: "Jak wygląda wdrożenie współpracy?",
+    content:
+      "Podpisujemy umowę B2B oraz NDA, ustalamy proces przekazywania danych klientów i tworzymy szablony dokumentów dostosowane do Twoich standardów. Pierwsze zlecenie realizujemy wspólnie, aby uspójnić komunikację.",
+    pageId: "ksiegowi-faq-1",
+  },
+  {
+    title: "Czy mogę rozliczać się ryczałtowo?",
+    content:
+      "Tak. Oferujemy rozliczenie abonamentowe z określonym limitem spraw miesięcznie lub elastyczny pakiet godzinowy, który możesz wykorzystać na konsultacje i przygotowanie dokumentów.",
+    pageId: "ksiegowi-faq-2",
+  },
+]
+
+export default function AccountantsPage() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">Dla księgowych (placeholder)</h1>
-    </main>
-  );
+    <div className="relative min-h-screen text-white">
+      <Script id="ksiegowi-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${accountantsBackground.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <Navbar />
+
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section className="mx-auto max-w-3xl text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Partner dla biur rachunkowych</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            Kompleksowa obsługa zmian KRS dla Twoich klientów
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Odciąż swój zespół i zyskaj pewność, że każdy wniosek jest przygotowany zgodnie z aktualnymi wymogami. Dostarczamy
+            dokumenty gotowe do podpisu oraz dbamy o komunikację z sądem rejestrowym.
+          </p>
+        </section>
+
+        <section className="grid gap-8 md:grid-cols-3">
+          {benefits.map((benefit) => (
+            <article key={benefit.title} className="rounded-2xl bg-slate-900/70 p-8 backdrop-blur">
+              <h2 className="text-xl font-semibold text-white">{benefit.title}</h2>
+              <p className="mt-4 text-sm text-slate-300">{benefit.description}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Standard obsługi white-label</h2>
+            <p className="text-slate-200">
+              Działamy w Twoich procesach – przygotowujemy checklisty dokumentów dla klientów, ustalamy sposób podpisywania i
+              raportujemy każdy etap. Możesz zaangażować nas zarówno w pojedyncze zgłoszenie, jak i stałą obsługę.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Szablony dokumentów dostosowane do identyfikacji Twojej marki.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Stały opiekun wdrożony w specyfikę klientów i branżę.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Raportowanie SLA oraz rekomendacje zmian w procedurach.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {faqs.map((faq) => (
+            <SEOExpandableSection key={faq.pageId} title={faq.title} content={faq.content} pageId={faq.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Zostań naszym partnerem</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            Porozmawiajmy o modelu współpracy, który najlepiej uzupełni usługi Twojego biura rachunkowego. Przygotujemy ofertę
+            oraz materiały startowe dla Twojego zespołu.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="/kontakt"
+          >
+            Umów spotkanie partnerskie
+          </a>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
 }

--- a/app/(site)/o-nas/page.tsx
+++ b/app/(site)/o-nas/page.tsx
@@ -1,14 +1,175 @@
-import Navbar from "@/components/Navbar";
-import Footer from "@/components/Footer";
+import type { Metadata } from "next"
+import Script from "next/script"
 
-export default function Page() {
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import aboutBackground from "@/public/images/solidne-fundamenty-prawne-eksperci-krs-doswiadczenie-wnioski-zmiana-wpisu.webp"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
+
+const pageUrl = `${siteUrl}/o-nas`
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "AboutPage",
+  name: "O nas - ZmianaKRS",
+  url: pageUrl,
+  publisher: organizationSchema,
+  description:
+    "Poznaj zespół ZmianaKRS odpowiedzialny za obsługę zmian w Krajowym Rejestrze Sądowym dla spółek i biur rachunkowych.",
+}
+
+export const metadata: Metadata = {
+  title: "O nas | ZmianaKRS",
+  description:
+    "Jesteśmy zespołem prawników, analityków i konsultantów ds. KRS. Od 2015 roku pomagamy spółkom sprawnie przechodzić przez zmiany w rejestrze.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "O nas | ZmianaKRS",
+    description:
+      "Dowiedz się, jak pracujemy przy obsłudze zmian w KRS. Poznaj proces, wartości i doświadczenie zespołu ZmianaKRS.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "Zespół ZmianaKRS",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Poznaj ZmianaKRS",
+    description: "Sprawdź, kto stoi za sukcesem setek obsłużonych zmian w KRS i jak wspieramy naszych klientów.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
+
+const milestones = [
+  {
+    year: "2015",
+    title: "Pierwsze projekty KRS",
+    description: "Rozpoczęliśmy działalność jako butikowa kancelaria wspierająca start-upy przy zmianach w rejestrze.",
+  },
+  {
+    year: "2018",
+    title: "Automatyzacja dokumentów",
+    description: "Zbudowaliśmy własny system szablonów uchwał i powiadomień dla klientów, skracając czas przygotowania akt.",
+  },
+  {
+    year: "2022",
+    title: "Zespół interdyscyplinarny",
+    description: "Dołączyli do nas analitycy finansowi, by zapewnić wsparcie także przy zmianach kapitałowych i reorganizacjach.",
+  },
+]
+
+const faqs = [
+  {
+    title: "Jak wygląda współpraca z klientem?",
+    content:
+      "Każdy projekt zaczyna się od warsztatu, podczas którego określamy zakres zmian, osoby odpowiedzialne i terminy. Następnie pracujemy sprintami, a o postępie informujemy w dedykowanym panelu lub w ustalonych raportach.",
+    pageId: "onas-faq-1",
+  },
+  {
+    title: "Z jakimi branżami pracujecie najczęściej?",
+    content:
+      "Najwięcej projektów prowadzimy dla spółek technologicznych, e-commerce, firm produkcyjnych oraz biur rachunkowych obsługujących sektor MŚP. Dostosowujemy proces do specyfiki branży.",
+    pageId: "onas-faq-2",
+  },
+]
+
+export default function AboutPage() {
   return (
-    <div className="about-background relative min-h-screen">
-      <div className="absolute inset-0 bg-slate-900/60 -z-10" />
-      <main className="p-8">
-        <h1 className="text-2xl font-semibold">O nas (placeholder)</h1>
+    <div className="relative min-h-screen text-white">
+      <Script id="onas-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${aboutBackground.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <Navbar />
+
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section className="text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Kim jesteśmy</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            Zespół specjalistów KRS, który prowadzi Cię przez zmiany bez stresu
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Łączymy doświadczenie prawników, project managerów i konsultantów finansowych. Dzięki temu potrafimy przygotować
+            kompleksową dokumentację i zadbać o każdy aspekt wpisu do KRS.
+          </p>
+        </section>
+
+        <section className="grid gap-6 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-3">
+          {milestones.map((milestone) => (
+            <article key={milestone.year} className="space-y-3">
+              <span className="text-sm uppercase tracking-widest text-amber-300">{milestone.year}</span>
+              <h2 className="text-xl font-semibold text-white">{milestone.title}</h2>
+              <p className="text-sm text-slate-300">{milestone.description}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Jak pracujemy?</h2>
+            <p className="text-slate-200">
+              Każdą zmianę traktujemy jak projekt biznesowy – z planem, odpowiedzialnościami i mierzalnym rezultatem. Dbamy o
+              komunikację z zarządem, księgowością i kancelarią notarialną, aby wszyscy interesariusze byli na bieżąco.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Dedykowany zespół projektowy z liderem odpowiedzialnym za terminy.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Narzędzia online do bezpiecznego przekazywania i akceptacji dokumentów.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Retrospektywa po zakończeniu projektu i rekomendacje dalszych działań.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {faqs.map((faq) => (
+            <SEOExpandableSection key={faq.pageId} title={faq.title} content={faq.content} pageId={faq.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Dołącz do grona naszych klientów</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            Chcesz dowiedzieć się więcej o naszym zespole i metodzie pracy? Zarezerwuj konsultację, a pokażemy Ci, jak możemy
+            wesprzeć Twoją spółkę.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="/kontakt"
+          >
+            Porozmawiaj z nami
+          </a>
+        </section>
       </main>
+
       <Footer />
     </div>
-  );
+  )
 }

--- a/app/(site)/polityka-prywatnosci/page.tsx
+++ b/app/(site)/polityka-prywatnosci/page.tsx
@@ -1,7 +1,159 @@
-export default function Page() {
+import type { Metadata } from "next"
+import Script from "next/script"
+
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import privacyBackground from "@/public/images/dokumenty-ksiegowe-zwyczajne-walne-zgromadzenie-krs.webp"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
+
+const pageUrl = `${siteUrl}/polityka-prywatnosci`
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "PrivacyPolicy",
+  name: "Polityka prywatności ZmianaKRS",
+  url: pageUrl,
+  publisher: organizationSchema,
+  inLanguage: "pl-PL",
+  description:
+    "Dowiedz się, jakie dane osobowe przetwarzamy podczas obsługi zmian w KRS oraz w jaki sposób je zabezpieczamy.",
+}
+
+export const metadata: Metadata = {
+  title: "Polityka prywatności | ZmianaKRS",
+  description:
+    "Sprawdź, w jaki sposób ZmianaKRS przetwarza dane osobowe i zapewnia bezpieczeństwo informacji podczas obsługi zmian w KRS.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "Polityka prywatności | ZmianaKRS",
+    description:
+      "Poznaj zasady przetwarzania danych osobowych i bezpieczeństwa informacji stosowane przez ZmianaKRS.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "Polityka prywatności ZmianaKRS",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Polityka prywatności ZmianaKRS",
+    description: "Informacje o przetwarzaniu danych osobowych klientów i partnerów biznesowych.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
+
+const sections = [
+  {
+    title: "Jakie dane przetwarzamy?",
+    content:
+      "Przetwarzamy dane identyfikacyjne osób reprezentujących spółkę, dane kontaktowe oraz dokumenty korporacyjne niezbędne do przygotowania wniosku. W przypadku pełnomocnictw gromadzimy także informacje o prokurentach i członkach zarządu.",
+    pageId: "privacy-1",
+  },
+  {
+    title: "Cele i podstawy prawne",
+    content:
+      "Dane przetwarzamy w celu przygotowania i złożenia wniosków do KRS (art. 6 ust. 1 lit. b RODO), realizacji obowiązków prawnych (art. 6 ust. 1 lit. c) oraz na podstawie uzasadnionego interesu administratora – m.in. w celu ochrony przed roszczeniami (art. 6 ust. 1 lit. f).",
+    pageId: "privacy-2",
+  },
+  {
+    title: "Okres przechowywania",
+    content:
+      "Dokumenty przechowujemy przez okres wymagany przepisami – zazwyczaj 6 lat od zakończenia współpracy. Na Twoje życzenie możemy przekazać pełną kopię dokumentacji oraz potwierdzenia złożenia wniosku.",
+    pageId: "privacy-3",
+  },
+  {
+    title: "Twoje prawa",
+    content:
+      "Masz prawo do dostępu do danych, ich sprostowania, ograniczenia przetwarzania, a także wniesienia sprzeciwu lub żądania usunięcia. W sprawach związanych z ochroną danych skontaktuj się z nami mailowo: rodo@zmianakrs.pl.",
+    pageId: "privacy-4",
+  },
+]
+
+export default function PrivacyPolicyPage() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">Polityka prywatności (placeholder)</h1>
-    </main>
-  );
+    <div className="relative min-h-screen text-white">
+      <Script id="privacy-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${privacyBackground.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <Navbar />
+
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section>
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Bezpieczeństwo danych</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            Polityka prywatności ZmianaKRS
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Dbamy o poufność informacji powierzonych nam podczas obsługi zmian w KRS. Poniżej znajdziesz szczegółowe zasady
+            przetwarzania danych osobowych oraz sposoby zabezpieczania dokumentacji.
+          </p>
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Administrator danych</h2>
+            <p className="text-slate-200">
+              Administratorem danych jest {brandName}, ul. Postępu 15, 02-676 Warszawa. W sprawach związanych z ochroną danych
+              skontaktuj się z nami pod adresem rodo@zmianakrs.pl lub telefonicznie +48 572 234 779.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Wdrażamy procedury kontroli dostępu oraz szyfrowania repozytoriów dokumentów.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Regularnie weryfikujemy upoważnienia oraz prowadzimy szkolenia z bezpieczeństwa informacji.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Prowadzimy rejestr czynności przetwarzania i testy procedur reagowania na incydenty.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {sections.map((section) => (
+            <SEOExpandableSection key={section.pageId} title={section.title} content={section.content} pageId={section.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Masz pytania dotyczące ochrony danych?</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            Skontaktuj się z naszym zespołem, aby otrzymać dodatkowe informacje lub zgłosić incydent bezpieczeństwa.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="mailto:rodo@zmianakrs.pl"
+          >
+            Napisz do inspektora danych
+          </a>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
 }

--- a/app/(site)/regulamin/page.tsx
+++ b/app/(site)/regulamin/page.tsx
@@ -1,7 +1,157 @@
-export default function Page() {
+import type { Metadata } from "next"
+import Script from "next/script"
+
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import termsBackground from "@/public/images/archiwum-dokumenty-spolek-zmiana-wpisu-krs.webp"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
+
+const pageUrl = `${siteUrl}/regulamin`
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "TermsOfService",
+  name: "Regulamin świadczenia usług ZmianaKRS",
+  url: pageUrl,
+  publisher: organizationSchema,
+  inLanguage: "pl-PL",
+}
+
+export const metadata: Metadata = {
+  title: "Regulamin | ZmianaKRS",
+  description:
+    "Zapoznaj się z warunkami świadczenia usług przez ZmianaKRS – zasady współpracy, płatności oraz odpowiedzialności.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "Regulamin | ZmianaKRS",
+    description:
+      "Warunki współpracy z ZmianaKRS przy obsłudze zmian w Krajowym Rejestrze Sądowym.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "Regulamin ZmianaKRS",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Regulamin ZmianaKRS",
+    description: "Sprawdź zasady współpracy, rozliczeń i odpowiedzialności przy obsłudze zmian w KRS.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
+
+const sections = [
+  {
+    title: "Zakres usług",
+    content:
+      "Świadczymy usługi polegające na analizie dokumentów, przygotowaniu wniosków do KRS, koordynacji podpisów elektronicznych, a także monitoringu postępowań rejestrowych. Zakres każdej współpracy opisujemy w umowie lub zleceniu.",
+    pageId: "terms-1",
+  },
+  {
+    title: "Zasady rozliczeń",
+    content:
+      "Wynagrodzenie ustalane jest w formie ryczałtu lub stawki godzinowej. Płatność następuje na podstawie faktury VAT z terminem 7 lub 14 dni. Opłaty sądowe i notarialne ponosi klient, chyba że strony uzgodnią inaczej.",
+    pageId: "terms-2",
+  },
+  {
+    title: "Odpowiedzialność",
+    content:
+      "Odpowiadamy za prawidłowość przygotowanych dokumentów i terminowość działań. Nie ponosimy odpowiedzialności za opóźnienia wynikające z działania sądu lub braku wymaganych podpisów ze strony klienta.",
+    pageId: "terms-3",
+  },
+  {
+    title: "Reklamacje",
+    content:
+      "Reklamacje możesz zgłosić mailowo na adres kontakt@zmianakrs.pl. Rozpatrujemy je w ciągu 14 dni roboczych. Jeśli reklamacja jest zasadna, proponujemy stosowne rozwiązanie – poprawę dokumentów, ponowne złożenie wniosku lub rekompensatę kosztów.",
+    pageId: "terms-4",
+  },
+]
+
+export default function TermsPage() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">Regulamin (placeholder)</h1>
-    </main>
-  );
+    <div className="relative min-h-screen text-white">
+      <Script id="terms-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${termsBackground.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <Navbar />
+
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section>
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Warunki współpracy</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            Regulamin świadczenia usług ZmianaKRS
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Regulamin określa zasady współpracy, odpowiedzialności i rozliczeń. Stanowi integralną część umowy podpisywanej z
+            klientem.
+          </p>
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Najważniejsze postanowienia</h2>
+            <p className="text-slate-200">
+              Przed rozpoczęciem projektu określamy harmonogram, osoby odpowiedzialne i kamienie milowe. Każda zmiana zakresu
+              wymaga potwierdzenia mailowego, aby zapewnić przejrzystość współpracy.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Wszystkie dokumenty przekazane przez klienta traktujemy jako poufne i wykorzystujemy wyłącznie do celów realizacji umowy.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Wynagrodzenie nie obejmuje kosztów zewnętrznych – opłat sądowych, notarialnych i podatkowych.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Klient zobowiązuje się dostarczyć wymagane dokumenty w terminie, aby uniknąć przesunięć w harmonogramie.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {sections.map((section) => (
+            <SEOExpandableSection key={section.pageId} title={section.title} content={section.content} pageId={section.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Chcesz rozpocząć współpracę?</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            Zapoznaj się z regulaminem i skontaktuj się z nami, aby przygotować umowę dopasowaną do Twojego projektu.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="/kontakt"
+          >
+            Porozmawiajmy o szczegółach
+          </a>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
 }

--- a/app/(site)/rodo/page.tsx
+++ b/app/(site)/rodo/page.tsx
@@ -1,7 +1,157 @@
-export default function Page() {
+import type { Metadata } from "next"
+import Script from "next/script"
+
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import gdprBackground from "@/public/images/dokumenty-zmiana-zarzadu-i-wpis-do-krs.webp"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
+
+const pageUrl = `${siteUrl}/rodo`
+
+const faqs = [
+  {
+    question: "Kto jest administratorem danych?",
+    answer:
+      "Administratorem danych osobowych jest ZmianaKRS z siedzibą w Warszawie. Możesz skontaktować się z nami mailowo: rodo@zmianakrs.pl lub telefonicznie +48 572 234 779.",
+    pageId: "rodo-faq-1",
+  },
+  {
+    question: "W jakim celu przetwarzamy dane?",
+    answer:
+      "Dane przetwarzamy, aby przygotować i złożyć wnioski do KRS, prowadzić korespondencję oraz wystawiać dokumenty księgowe. Na podstawie odrębnej zgody możemy prowadzić komunikację marketingową.",
+    pageId: "rodo-faq-2",
+  },
+  {
+    question: "Komu udostępniamy dane?",
+    answer:
+      "Dane przekazujemy tylko podmiotom wspierającym realizację usługi – notariuszom, kancelariom współpracującym, dostawcom podpisów elektronicznych oraz operatorom systemów teleinformatycznych, z którymi łączą nas umowy powierzenia.",
+    pageId: "rodo-faq-3",
+  },
+]
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
+    },
+  })),
+  url: pageUrl,
+  publisher: organizationSchema,
+}
+
+export const metadata: Metadata = {
+  title: "RODO | ZmianaKRS",
+  description:
+    "Informacje o ochronie danych osobowych w ZmianaKRS – administrator, cele przetwarzania, odbiorcy danych i prawa osób.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "RODO | ZmianaKRS",
+    description:
+      "Dowiedz się, jak ZmianaKRS realizuje obowiązki wynikające z RODO i jak możesz skorzystać ze swoich praw.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "RODO ZmianaKRS",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "RODO ZmianaKRS",
+    description: "Poznaj zasady ochrony danych osobowych stosowane przez ZmianaKRS.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
+
+export default function RodoPage() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">RODO (placeholder)</h1>
-    </main>
-  );
+    <div className="relative min-h-screen text-white">
+      <Script id="rodo-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${gdprBackground.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <Navbar />
+
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section>
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Ochrona danych osobowych</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            RODO w ZmianaKRS
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Poznaj informacje o tym, jak realizujemy obowiązki wynikające z RODO i jak wspieramy klientów w ochronie danych
+            osobowych podczas procesów rejestrowych.
+          </p>
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Zasady bezpieczeństwa</h2>
+            <p className="text-slate-200">
+              Korzystamy z szyfrowanych repozytoriów dokumentów, weryfikujemy dostęp do systemów i prowadzimy rejestr czynności
+              przetwarzania. Każdy członek zespołu przechodzi cykliczne szkolenia z ochrony danych.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Stosujemy dwuskładnikowe uwierzytelnianie w systemach przechowywania plików i podpisów elektronicznych.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Regularnie testujemy procedury odzyskiwania danych i reagowania na incydenty.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Zapewniamy audyt ścieżki dokumentu – od przygotowania po archiwizację.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {faqs.map((faq) => (
+            <SEOExpandableSection key={faq.pageId} title={faq.question} content={faq.answer} pageId={faq.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Potrzebujesz wsparcia przy RODO?</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            Pomożemy przygotować dokumentację powierzenia przetwarzania oraz procedury dla Twojej organizacji.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="mailto:rodo@zmianakrs.pl"
+          >
+            Skontaktuj się z nami
+          </a>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
 }

--- a/app/(site)/uslugi/ServicesList.tsx
+++ b/app/(site)/uslugi/ServicesList.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+interface Service {
+  id: number
+  name: string
+  description: string
+}
+
+export default function ServicesList() {
+  const { data, isLoading } = useQuery<Service[]>({
+    queryKey: ["services"],
+    queryFn: async () => {
+      const response = await fetch("/api/services")
+      if (!response.ok) {
+        throw new Error("Nie udało się pobrać listy usług")
+      }
+      return response.json()
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl bg-slate-900/70 p-8 text-center text-slate-200">
+        Ładujemy aktualną listę usług...
+      </div>
+    )
+  }
+
+  if (!data?.length) {
+    return (
+      <div className="rounded-2xl bg-slate-900/70 p-8 text-center text-slate-200">
+        Obecnie aktualizujemy listę usług. Skontaktuj się z nami, aby otrzymać indywidualną ofertę.
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      {data.map((service) => (
+        <article key={service.id} className="rounded-2xl bg-slate-900/70 p-6 backdrop-blur">
+          <h3 className="text-xl font-semibold text-white">{service.name}</h3>
+          <p className="mt-3 text-sm text-slate-300">{service.description}</p>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/app/(site)/uslugi/page.tsx
+++ b/app/(site)/uslugi/page.tsx
@@ -1,38 +1,189 @@
-"use client";
+import type { Metadata } from "next"
+import Script from "next/script"
 
-import { useQuery } from "@tanstack/react-query";
+import Footer from "@/components/Footer"
+import Navbar from "@/components/Navbar"
+import SEOExpandableSection from "@/components/SEOExpandableSection"
+import servicesBackground from "@/public/images/outsourcing-zmian-krs-kompleksowa-obsluga-dla-przedsiebiorcow-i-ksiegowych.webp"
+import ServicesList from "./ServicesList"
+import { brandName, organizationSchema, siteUrl } from "@/lib/seo"
 
-interface Service {
-  id: number;
-  name: string;
-  description: string;
+const pageUrl = `${siteUrl}/uslugi`
+
+const keyServices = [
+  {
+    title: "Zmiana danych w KRS",
+    description:
+      "Przygotowanie kompletu dokumentów do aktualizacji danych zarządu, wspólników i kapitału zakładowego wraz z reprezentacją przed sądem.",
+  },
+  {
+    title: "Obsługa walnych zgromadzeń",
+    description:
+      "Wsparcie w organizacji WZ, przygotowaniu uchwał i protokołów, a następnie zgłoszeniu zmian w rejestrze.",
+  },
+  {
+    title: "Reorganizacje i przekształcenia",
+    description:
+      "Koordynacja zmian formy prawnej, aportów i restrukturyzacji grup kapitałowych w modelu projektowym.",
+  },
+]
+
+const faqs = [
+  {
+    title: "Jak wygląda standardowa obsługa?",
+    content:
+      "Rozpoczynamy od analizy dokumentów i przygotowania harmonogramu. Następnie pracujemy etapami: dokumenty, podpisy, wniosek, monitoring i zamknięcie projektu z przekazaniem archiwum.",
+    pageId: "services-faq-1",
+  },
+  {
+    title: "Czy pomagacie w sprawach pilnych?",
+    content:
+      "Tak. Dla zgłoszeń wymagających szybkiej reakcji uruchamiamy tryb ekspresowy – dokumenty trafiają do podpisu w ciągu 24h, a wniosek składamy po otrzymaniu wszystkich pełnomocnictw.",
+    pageId: "services-faq-2",
+  },
+]
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Obsługa zmian w KRS",
+  url: pageUrl,
+  provider: organizationSchema,
+  hasOfferCatalog: {
+    "@type": "OfferCatalog",
+    name: "Zakres usług",
+    itemListElement: keyServices.map((service) => ({
+      "@type": "Offer",
+      itemOffered: {
+        "@type": "Service",
+        name: service.title,
+        description: service.description,
+      },
+    })),
+  },
 }
 
-export default function Page() {
-  const { data: services, isLoading } = useQuery<Service[]>({
-    queryKey: ["/api/services"],
-    queryFn: () => fetch("/api/services").then((res) => res.json()),
-  });
+export const metadata: Metadata = {
+  title: "Usługi KRS | ZmianaKRS",
+  description:
+    "Kompleksowa obsługa zmian w KRS – od przygotowania dokumentów po monitorowanie wpisu. Sprawdź, jak możemy pomóc Twojej spółce.",
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: {
+    title: "Usługi KRS | ZmianaKRS",
+    description:
+      "Zmiana zarządu, aktualizacja umowy spółki, rejestracja prokury – poznaj pełny zakres usług ZmianaKRS.",
+    url: pageUrl,
+    siteName: brandName,
+    images: [
+      {
+        url: `${siteUrl}/images/krs-services.png`,
+        width: 1200,
+        height: 630,
+        alt: "Usługi ZmianaKRS",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Usługi KRS",
+    description: "Profesjonalna obsługa zmian w Krajowym Rejestrze Sądowym dla spółek i biur rachunkowych.",
+    images: [`${siteUrl}/images/krs-services.png`],
+  },
+}
 
-  if (isLoading) {
-    return (
-      <main className="p-8">
-        <h1 className="text-2xl font-semibold">Ładowanie...</h1>
-      </main>
-    );
-  }
-
+export default function ServicesPage() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold mb-4">Usługi</h1>
-      <ul className="space-y-4">
-        {services?.map((service) => (
-          <li key={service.id}>
-            <h2 className="text-xl font-medium">{service.name}</h2>
-            <p className="text-sm text-gray-600">{service.description}</p>
-          </li>
-        ))}
-      </ul>
-    </main>
-  );
+    <div className="relative min-h-screen text-white">
+      <Script id="services-structured-data" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </Script>
+
+      <div
+        className="fixed inset-0 -z-10 bg-slate-950/80"
+        style={{
+          backgroundImage: `url(${servicesBackground.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      <Navbar />
+
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-20 lg:py-24">
+        <section className="mx-auto max-w-3xl text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-amber-300">Zakres wsparcia</p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight md:text-5xl">
+            Usługi obsługi zmian w KRS
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            Zapewniamy kompleksowe wsparcie – od przygotowania uchwał i pełnomocnictw, przez koordynację podpisów, po monitorowanie
+            wpisu w Krajowym Rejestrze Sądowym.
+          </p>
+        </section>
+
+        <section className="grid gap-8 md:grid-cols-3">
+          {keyServices.map((service) => (
+            <article key={service.title} className="rounded-2xl bg-slate-900/70 p-8 backdrop-blur">
+              <h2 className="text-xl font-semibold text-white">{service.title}</h2>
+              <p className="mt-4 text-sm text-slate-300">{service.description}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-2xl font-semibold">Aktualna lista usług</h2>
+          <ServicesList />
+        </section>
+
+        <section className="grid gap-10 rounded-3xl bg-slate-900/60 px-8 py-12 backdrop-blur md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">Jak przebiega współpraca?</h2>
+            <p className="text-slate-200">
+              Pracujemy według sprawdzonego procesu obejmującego analizę stanu prawnego, przygotowanie dokumentów, pozyskanie podpisów
+              oraz koordynację wysyłki i monitoringu sprawy.
+            </p>
+          </div>
+          <div>
+            <ul className="space-y-3 text-sm text-slate-200">
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Stały kontakt z dedykowanym opiekunem – telefonicznie, mailowo i w panelu klienta.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Możliwość reprezentacji przed sądem rejestrowym na podstawie pełnomocnictwa.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                <span>Pełna dokumentacja powykonawcza wraz z instrukcją przechowywania i dalszych zgłoszeń.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          {faqs.map((faq) => (
+            <SEOExpandableSection key={faq.pageId} title={faq.title} content={faq.content} pageId={faq.pageId} />
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-amber-500/10 px-10 py-12 text-center text-slate-900 backdrop-blur">
+          <h2 className="text-3xl font-semibold text-white">Potrzebujesz indywidualnej oferty?</h2>
+          <p className="mt-4 text-base text-slate-100 md:text-lg">
+            Przekaż nam zakres planowanych zmian. Przygotujemy harmonogram, listę dokumentów oraz wycenę dostosowaną do Twoich potrzeb.
+          </p>
+          <a
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-amber-500 px-8 py-3 text-base font-semibold text-slate-900 transition hover:bg-amber-400"
+            href="/kontakt"
+          >
+            Porozmawiajmy o projekcie
+          </a>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
 }

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -9,13 +9,27 @@ interface Service {
 const services: Service[] = [
   {
     id: 1,
-    name: "Rejestracja spółki",
-    description: "Pomoc w rejestracji spółki w KRS.",
+    name: "Zmiana danych zarządu",
+    description:
+      "Przygotowanie uchwał, aktualizacja danych w KRS oraz koordynacja podpisów elektronicznych dla nowych członków zarządu.",
   },
   {
     id: 2,
-    name: "Zmiany w KRS",
-    description: "Obsługa wniosków o zmianę w KRS.",
+    name: "Aktualizacja umowy spółki",
+    description:
+      "Kompleksowa obsługa zmian w umowie spółki, w tym rozszerzenie PKD, zmiana siedziby oraz dostosowanie zapisów do aktualnych przepisów.",
+  },
+  {
+    id: 3,
+    name: "Przekształcenia i reorganizacje",
+    description:
+      "Wsparcie przy przekształceniach formy prawnej, aportach i zmianach struktury kapitałowej wraz z dokumentacją dla sądu rejestrowego.",
+  },
+  {
+    id: 4,
+    name: "Rejestracja prokury i pełnomocnictw",
+    description:
+      "Opracowanie pełnomocnictw, zgłoszenie prokury w KRS oraz zapewnienie kompletnej dokumentacji dla banków i kontrahentów.",
   },
 ];
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -50,9 +50,9 @@ export default function Footer() {
                 <p className="font-medium text-white">Telefon</p>
                 <a
                   className="mt-1 block text-slate-300 transition hover:text-white"
-                  href="tel:+48500100200"
+                  href="tel:+48572234779"
                 >
-                  +48 500 100 200
+                  +48 572 234 779
                 </a>
               </div>
               <div>

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,23 @@
+export const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://zmianakrs.pl"
+
+export const brandName = "ZmianaKRS"
+
+export const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "ProfessionalService",
+  name: brandName,
+  url: siteUrl,
+  logo: `${siteUrl}/images/krs-logo.png`,
+  sameAs: [
+    "https://www.facebook.com/zmianakrs",
+    "https://www.linkedin.com/company/zmianakrs",
+  ],
+  contactPoint: {
+    "@type": "ContactPoint",
+    telephone: "+48572234779",
+    contactType: "customer service",
+    areaServed: "PL",
+    availableLanguage: ["pl-PL"],
+  },
+}


### PR DESCRIPTION
## Summary
- build full layouts, copy, and structured data for the cennik, contact, ksiegowi, o-nas, polityka-prywatnosci, regulamin, rodo, and uslugi routes using shared site components
- add shared SEO helpers and align the public phone number in the footer with navigation details
- expand the services API and render it through a react-query client component on the services page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2398ed3488330b6fba01fc6239f27