### PR TITLE
Redesign features section layout

### DIFF
--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -1,59 +1,64 @@
-import React from 'react'
-import Image from 'next/image'
 import Link from 'next/link'
 
-const benefits = [
+const features = [
   {
-    src: '/icons/dostepnosc.svg',
-    alt: 'Ikona dostępności',
+    icon: '🕒',
     title: 'Dostępność',
-    description: 'Jesteśmy do Twojej dyspozycji, gdy tylko nas potrzebujesz.',
+    description:
+      'Jesteśmy tuż obok, gdy tylko Twoja firma potrzebuje wsparcia – zarówno w sprawach pilnych, jak i przy codziennych formalnościach.',
     href: '/uslugi',
   },
   {
-    src: '/icons/profesjonalizm.svg',
-    alt: 'Ikona profesjonalizmu',
+    icon: '🤝',
     title: 'Profesjonalizm',
-    description: 'Zapewniamy rzetelną obsługę opartą na doświadczeniu.',
+    description:
+      'Każde zlecenie prowadzą eksperci z wieloletnim doświadczeniem, dbając o terminowość i najwyższą jakość obsługi.',
     href: '/o-nas',
   },
   {
-    src: '/icons/prosty-cennik.svg',
-    alt: 'Ikona prostego cennika',
+    icon: '📄',
     title: 'Prosty cennik',
-    description: 'Przejrzyste stawki bez ukrytych kosztów.',
+    description:
+      'Przejrzyste warunki współpracy i brak ukrytych kosztów – od początku wiesz, za co płacisz.',
     href: '/cennik',
   },
 ]
 
 export default function Features() {
   return (
-    <section className="py-20">
-      <div className="max-w-6xl mx-auto px-4">
-        <h2 className="text-2xl font-semibold text-center mb-4">
-          Dlaczego warto z nami współpracować?
-        </h2>
-        <p className="text-sm text-gray-600 text-justify mb-12">
-          Ponad 10 lat doświadczenia w obsłudze firm. Zaufały nam już setki
-          przedsiębiorców.
-        </p>
-        <div className="grid md:grid-cols-3 gap-8">
-          {benefits.map(({ src, alt, title, description, href }) => (
-            <div key={title} className="text-center">
-              <Image
-                src={src}
-                alt={alt}
-                width={64}
-                height={64}
-                className="mx-auto mb-4"
-              />
-              <h3 className="font-semibold mb-2">{title}</h3>
-              <p className="text-sm text-gray-600 text-justify">
-                {description}
-              </p>
+    <section className="py-24">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mx-auto mb-12 max-w-3xl text-center">
+          <h2 className="text-3xl font-semibold text-white md:text-4xl">
+            Dlaczego Wybierają Nas Klienci
+          </h2>
+          <p className="mt-4 text-lg text-gray-200">
+            Ponad 10 lat doświadczenia w obsłudze firm. Zaufały nam już setki
+            przedsiębiorców.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3">
+          {features.map(({ icon, title, description, href }) => (
+            <div
+              key={title}
+              className="flex h-full flex-col justify-between rounded-2xl border border-white/20 bg-white/10 p-6 text-left backdrop-blur-sm transition-colors duration-150 hover:bg-white/15 sm:p-8"
+            >
+              <div>
+                {icon ? (
+                  <span className="inline-flex h-12 w-12 items-center justify-center text-3xl" aria-hidden="true">
+                    {icon}
+                  </span>
+                ) : null}
+                <h3 className="mt-6 text-2xl font-semibold text-white">
+                  {title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-gray-200">
+                  {description}
+                </p>
+              </div>
               <Link
                 href={href}
-                className="mt-2 text-sm text-blue-600 hover:underline"
+                className="mt-4 inline-flex w-full items-center justify-center rounded-lg bg-amber-600 px-4 py-3 text-sm font-semibold text-white transition-colors duration-150 hover:bg-amber-700"
               >
                 Dowiedz się więcej
               </Link>


### PR DESCRIPTION
## Summary
- redesign the features section with a centered heading and refreshed copy
- introduce translucent feature cards with full-width calls to action linking to key pages
- fine-tune feature card transparency and button styling to match the provided palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d529609e0483309efdee4a95665e91