### PR TITLE
fix: align navbar with design

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,10 +6,17 @@ import { usePathname } from "next/navigation";
 
 export default function Navbar() {
   const pathname = usePathname();
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
 
   const navItems = [
     { href: "/", label: "Strona główna" },
+    { href: "/o-nas", label: "O nas" },
     { href: "/uslugi", label: "Usługi" },
+    { href: "/ksiegowi", label: "Dla księgowych" },
     { href: "/cennik", label: "Cennik" },
     { href: "/blog", label: "Blog" },
     { href: "/kontakt", label: "Kontakt" },
@@ -23,43 +30,105 @@ export default function Navbar() {
       : pathname.startsWith(href);
 
   return (
-    <header className="w-full">
-      <div className="bg-gray-700 text-gray-100 text-sm">
-        <div className="w-4/5 max-w-7xl mx-auto flex justify-between items-center px-4 py-4">
-          <div className="flex gap-4">
-            <a
-              href="tel:572234779"
-              className="text-gray-100 transition-colors hover:text-amber-400"
-            >
-              {"572\u202f234\u202f779"}
-            </a>
-            <a
-              href="mailto:kontakt@zmianakrs.pl"
-              className="text-gray-100 transition-colors hover:text-amber-400"
-            >
-              kontakt@zmianakrs.pl
-            </a>
-          </div>
-          <nav className="hidden sm:block">
-            <ul className="flex gap-6">
-              {navItems.map((item) => (
+    <header className="w-full bg-[#4a2816] text-amber-50 shadow-md">
+      <div className="mx-auto flex w-11/12 max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-3 text-sm">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <a
+            href="tel:572234779"
+            className="font-semibold tracking-wide text-amber-50 transition-colors hover:text-amber-300"
+          >
+            {"572\u202f234\u202f779"}
+          </a>
+          <a
+            href="mailto:kontakt@zmianakrs.pl"
+            className="text-amber-100 transition-colors hover:text-amber-300"
+          >
+            kontakt@zmianakrs.pl
+          </a>
+        </div>
+        <button
+          type="button"
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-amber-200 text-amber-50 transition-colors hover:border-amber-300 hover:text-amber-200 md:hidden"
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+          aria-expanded={isMenuOpen}
+          aria-controls="mobile-navigation"
+          aria-label={isMenuOpen ? "Zamknij menu" : "Otwórz menu"}
+        >
+          <span className="sr-only">Przełącz menu</span>
+          <svg
+            className="h-5 w-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            {isMenuOpen ? (
+              <path
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            ) : (
+              <path
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            )}
+          </svg>
+        </button>
+        <nav className="hidden md:block">
+          <ul className="flex items-center gap-1 lg:gap-2">
+            {navItems.map((item) => {
+              const active = isActive(item.href);
+              return (
                 <li key={item.href}>
                   <Link
                     href={item.href}
-                    className={`inline-block px-3 py-4 text-gray-100 transition-colors ${
-                      isActive(item.href)
-                        ? "text-gray-900 font-semibold bg-amber-400 rounded"
-                        : "hover:bg-amber-400 hover:text-gray-900 rounded"
+                    aria-current={active ? "page" : undefined}
+                    className={`inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                      active
+                        ? "bg-amber-400 text-[#4a2816]"
+                        : "text-amber-100 hover:bg-amber-300 hover:text-[#4a2816]"
                     }`}
                   >
                     {item.label}
                   </Link>
                 </li>
-              ))}
+              );
+            })}
+          </ul>
+        </nav>
+      </div>
+      {isMenuOpen ? (
+        <div className="border-t border-amber-300/40 bg-[#3b1e10] md:hidden" id="mobile-navigation">
+          <nav className="mx-auto w-11/12 max-w-7xl px-4 py-4">
+            <ul className="flex flex-col gap-2 text-sm">
+              {navItems.map((item) => {
+                const active = isActive(item.href);
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      aria-current={active ? "page" : undefined}
+                      className={`block rounded-lg px-4 py-3 font-medium transition-colors ${
+                        active
+                          ? "bg-amber-400 text-[#4a2816]"
+                          : "text-amber-100 hover:bg-amber-300 hover:text-[#4a2816]"
+                      }`}
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
           </nav>
         </div>
-      </div>
+      ) : null}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- align the navbar with the provided single-row layout, keeping the contact information bar and amber active styling
- add missing "O nas" and "Dla księgowych" links that route to their respective pages while retaining the responsive mobile toggle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e39b670a2c8330bdad226e3d391f5c