### PR TITLE
Darken homepage hero overlay for improved contrast

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -64,7 +64,7 @@ Skontaktuj się z nami, aby dowiedzieć się więcej o naszych usługach KRS dla
   return (
     <div className="relative">
       <div
-        className="fixed inset-0 -z-10 bg-slate-900/75"
+        className="fixed inset-0 -z-10 bg-slate-950/90"
         style={{
           backgroundImage: `url(${professionalWaitingRoomImage.src})`,
           backgroundSize: "cover",


### PR DESCRIPTION
## Summary
- darkened the homepage hero overlay to bg-slate-950/90 to improve text contrast on the landing page hero

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e614ed2d60833097943347e4b97d65