### PR TITLE
Enhance homepage hero overlay darkness

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -64,13 +64,15 @@ Skontaktuj się z nami, aby dowiedzieć się więcej o naszych usługach KRS dla
   return (
     <div className="relative">
       <div
-        className="fixed inset-0 -z-10 bg-slate-900/75"
+        className="fixed inset-0 -z-20"
         style={{
           backgroundImage: `url(${professionalWaitingRoomImage.src})`,
           backgroundSize: "cover",
           backgroundPosition: "center",
         }}
+        aria-hidden
       />
+      <div className="fixed inset-0 -z-10 bg-slate-950/90" aria-hidden />
       <Navbar />
       <main>
         <Hero />

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -72,7 +72,7 @@ Skontaktuj się z nami, aby dowiedzieć się więcej o naszych usługach KRS dla
         }}
         aria-hidden
       />
-      <div className="fixed inset-0 -z-10 bg-slate-950/90" aria-hidden />
+      <div className="fixed inset-0 -z-10 bg-slate-950/80" aria-hidden />
       <Navbar />
       <main>
         <Hero />


### PR DESCRIPTION
## Summary
- separate the homepage hero background image from a dedicated slate overlay layer for a true darkening effect

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e614ed2d60833097943347e4b97d65