### PR TITLE
Adjust homepage spacing to match React reference

### DIFF
--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -33,18 +33,18 @@ const features: Feature[] = [
 
 export default function Features() {
   return (
-    <section className="py-24">
+    <section className="py-16">
       <div className="mx-auto w-full px-6 sm:px-8">
-        <div className="mx-auto mb-12 max-w-3xl text-center">
+        <div className="mx-auto mb-8 max-w-3xl text-center">
           <h2 className="text-3xl font-semibold text-white md:text-4xl">
             Dlaczego Wybierają Nas Klienci
           </h2>
-          <p className="mt-4 text-lg text-gray-200">
+          <p className="mt-3 text-lg text-gray-200">
             Ponad 10 lat doświadczenia w obsłudze firm. Zaufały nam już setki
             przedsiębiorców.
           </p>
         </div>
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
           {features.map(({ icon, title, description, href }) => (
             <div
               key={title}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,21 +4,21 @@ import Image from 'next/image'
 
 export default function Hero() {
   return (
-    <section className="flex flex-col items-center justify-center text-center py-32 px-4 sm:py-40 bg-transparent">
+    <section className="flex flex-col items-center justify-center text-center py-20 px-4 sm:py-24 bg-transparent">
       <div className="w-4/5 mx-auto text-white">
-        <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-6 sm:mb-8 leading-tight">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-5 sm:mb-6 leading-tight">
           Zmiana wpisu w <span className="text-amber-400">KRS</span>{' '}
           <br className="hidden md:block" />
           bez stresu i błędów – zrobimy to za Ciebie
         </h1>
-        <p className="text-lg sm:text-xl md:text-2xl mb-6 sm:mb-8 text-gray-300 leading-relaxed text-justify">
+        <p className="text-lg sm:text-xl md:text-2xl mb-4 sm:mb-6 text-gray-300 leading-relaxed text-justify">
           Wiemy, jak uciążliwe, czasochłonne i frustrujące bywa samodzielne składanie wniosku o zmianę wpisu w KRS. Przez ostatnie lata pomogliśmy setkom klientów z całej Polski skutecznie przejść przez ten proces — bez błędów, bez zwrotów i bez nerwów.
         </p>
-        <p className="text-lg sm:text-xl md:text-2xl mb-6 sm:mb-8 text-gray-300 leading-relaxed text-justify">
+        <p className="text-lg sm:text-xl md:text-2xl mb-4 sm:mb-6 text-gray-300 leading-relaxed text-justify">
           Nie ma znaczenia, gdzie mieszkasz — działamy zdalnie, profesjonalnie i kompleksowo. Od przygotowania dokumentów po złożenie kompletnego wniosku elektronicznego i uzyskanie prawomocnego wpisu.
         </p>
       </div>
-      <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+      <div className="mt-6 flex flex-col sm:flex-row gap-4 justify-center">
         <Link
           href="/uslugi"
           className="w-full sm:w-auto bg-amber-800 hover:bg-amber-900 text-white px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-semibold rounded-lg transition-colors duration-150 text-center"

--- a/components/Trust.tsx
+++ b/components/Trust.tsx
@@ -5,23 +5,23 @@ import Link from "next/link"
 export default function Trust() {
   return (
     <>
-      <section className="relative py-16 px-4 sm:px-6 lg:px-8">
+      <section className="relative py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">
-          <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg p-8 sm:p-12">
-            <h2 className="text-2xl sm:text-3xl font-bold text-white mb-6 text-center">
+          <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg p-6 sm:p-10">
+            <h2 className="text-2xl sm:text-3xl font-bold text-white mb-5 text-center">
               Profesjonalna obsługa wniosków o zmianę wpisu w KRS
             </h2>
 
-            <h3 className="text-xl sm:text-2xl font-semibold text-amber-400 mb-4 text-center">
+            <h3 className="text-xl sm:text-2xl font-semibold text-amber-400 mb-3 text-center">
               Aktualizacja danych w KRS – obowiązek, którego nie warto odkładać
             </h3>
 
-            <div className="space-y-6 text-gray-300 leading-relaxed">
+            <div className="space-y-5 text-gray-300 leading-relaxed">
               <p className="text-base sm:text-lg">
                 Zmiana danych w KRS to nie tylko formalność – to prawny obowiązek każdej spółki wpisanej do rejestru. Niedopełnienie go może skutkować poważnymi konsekwencjami: grzywną, odpowiedzialnością członków zarządu, a nawet odmową wykonania czynności przez kontrahenta czy notariusza.
               </p>
 
-              <h3 className="text-lg sm:text-xl font-semibold text-amber-400 mt-6 mb-4">
+              <h3 className="text-lg sm:text-xl font-semibold text-amber-400 mt-5 mb-3">
                 Kompleksowa obsługa zmian w KRS
               </h3>
 
@@ -41,7 +41,7 @@ export default function Trust() {
                 lub dopisaniu prokurenta.
               </p>
 
-              <h3 className="text-lg sm:text-xl font-semibold text-amber-400 mt-6 mb-4">
+              <h3 className="text-lg sm:text-xl font-semibold text-amber-400 mt-5 mb-3">
                 Profesjonalne wsparcie w procesie zmiany wpisu w KRS
               </h3>
 
@@ -65,12 +65,12 @@ export default function Trust() {
                 .
               </p>
 
-              <div className="text-center mt-8">
-                <p className="text-lg sm:text-xl font-semibold text-amber-400 mb-6">
+              <div className="text-center mt-6">
+                <p className="text-lg sm:text-xl font-semibold text-amber-400 mb-5">
                   Skorzystaj z doświadczenia i uniknij błędów – powierz wpis zmian do KRS profesjonalistom.
                 </p>
 
-                <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-6">
+                <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-5">
                   <Link href="/blog" className="text-amber-400 hover:text-amber-300 underline text-lg">
                     Blog
                   </Link>
@@ -96,9 +96,9 @@ export default function Trust() {
         </div>
       </section>
 
-      <section className="w-full px-4 md:px-8 lg:px-16 py-12 space-y-10">
+      <section className="w-full px-4 md:px-8 lg:px-16 py-10 space-y-8">
         <div className="max-w-6xl mx-auto">
-          <h1 className="text-3xl lg:text-4xl font-bold mb-6 text-center text-white">
+          <h1 className="text-3xl lg:text-4xl font-bold mb-5 text-center text-white">
             Czym jest Krajowy Rejestr Sądowy (KRS)?
           </h1>
 
@@ -115,17 +115,17 @@ export default function Trust() {
             Wejście do budynku z tablicą „Krajowy Rejestr Sądowy&quot; – symbol jawności i legalności rejestrów.
           </p>
 
-          <p className="text-base sm:text-lg leading-relaxed mb-6 text-white">
+          <p className="text-base sm:text-lg leading-relaxed mb-5 text-white">
             <strong>Krajowy Rejestr Sądowy (KRS)</strong> to centralny, jawny rejestr publiczny prowadzony przez sądy rejestrowe (działające w strukturze sądów okręgowych) zgodnie z ustawą z dnia 20 sierpnia 1997 r. o Krajowym Rejestrze Sądowym (Dz.U. z 2023 r. poz. 685). Rejestr ten stanowi kluczowy filar przejrzystości i bezpieczeństwa obrotu prawnego i gospodarczego w Polsce.
           </p>
 
-          <ul className="list-disc list-inside my-6 space-y-2 text-white text-base sm:text-lg">
+          <ul className="list-disc list-inside my-5 space-y-2 text-white text-base sm:text-lg">
             <li>Rejestr przedsiębiorców</li>
             <li>Rejestr stowarzyszeń, fundacji i organizacji</li>
             <li>Krajowy Rejestr Zadłużonych (KRZ)</li>
           </ul>
 
-          <p className="text-base sm:text-lg leading-relaxed mb-6 text-white">
+          <p className="text-base sm:text-lg leading-relaxed mb-5 text-white">
             Zgodnie z art. 8 ust. 1 uKRS, rejestr jest jawny – każdy ma prawo dostępu do danych bez wykazywania interesu prawnego. Wpisy korzystają z domniemania prawdziwości (art. 17 uKRS) i są dostępne przez wyszukiwarkę eKRS.{" "}
             <Link href="/uslugi" className="text-amber-400 hover:text-amber-300 font-semibold underline">
               Profesjonalna obsługa zmian w KRS
@@ -133,7 +133,7 @@ export default function Trust() {
             gwarantuje zgodność z wszystkimi wymogami prawnymi.
           </p>
 
-          <h2 className="text-2xl font-semibold mt-10 mb-4 text-white">
+          <h2 className="text-2xl font-semibold mt-8 mb-3 text-white">
             Jakie dane ujawnia się w KRS?
           </h2>
 
@@ -150,23 +150,23 @@ export default function Trust() {
             Przechowywane dokumenty finansowe w repozytorium KRS – dostępność i obowiązki informacyjne spółek.
           </p>
 
-          <p className="text-base sm:text-lg leading-relaxed mb-6 text-white">
+          <p className="text-base sm:text-lg leading-relaxed mb-5 text-white">
             W zależności od podmiotu, KRS zawiera m.in. dane identyfikacyjne (KRS, NIP, REGON), firmę, formę prawną, PKD, organy reprezentacji, wspólników, kapitał zakładowy, adresy, postępowania upadłościowe i restrukturyzacyjne, dane pełnomocników, kuratorów oraz złożone dokumenty.
           </p>
 
-          <h2 className="text-2xl font-semibold mt-10 mb-4 text-white">
+          <h2 className="text-2xl font-semibold mt-8 mb-3 text-white">
             Kto podlega obowiązkowi rejestracji w KRS?
           </h2>
 
-          <p className="text-base sm:text-lg leading-relaxed mb-6 text-white">
+          <p className="text-base sm:text-lg leading-relaxed mb-5 text-white">
             W rejestrze przedsiębiorców ujmuje się spółki osobowe i kapitałowe, spółdzielnie, przedsiębiorstwa państwowe, oddziały firm zagranicznych i inne jednostki na podstawie przepisów szczególnych. Rejestr stowarzyszeń obejmuje fundacje, stowarzyszenia, związki zawodowe, izby gospodarcze i inne organizacje społeczne.
           </p>
 
-          <h2 className="text-2xl font-semibold mt-10 mb-4 text-white">
+          <h2 className="text-2xl font-semibold mt-8 mb-3 text-white">
             Charakter wpisów – konstytutywny i deklaratoryjny
           </h2>
 
-          <p className="text-base sm:text-lg leading-relaxed mb-6 text-white">
+          <p className="text-base sm:text-lg leading-relaxed mb-5 text-white">
             Wpis może tworzyć skutki prawne (konstytutywny) lub je jedynie potwierdzać (deklaratoryjny). Przykładowo:{" "}
             <Link href="/uslugi" className="text-amber-400 hover:text-amber-300 font-semibold underline">
               zmiana umowy spółki
@@ -174,11 +174,11 @@ export default function Trust() {
             wymaga wpisu do KRS (konstytutywny), natomiast powołanie członka zarządu skuteczne jest od uchwały, choć wpis ma znaczenie dla bezpieczeństwa obrotu (art. 17 uKRS).
           </p>
 
-          <h2 className="text-2xl font-semibold mt-10 mb-4 text-white">
+          <h2 className="text-2xl font-semibold mt-8 mb-3 text-white">
             Tryby elektroniczne: PRS i S24
           </h2>
 
-          <p className="text-base sm:text-lg leading-relaxed mb-6 text-white">
+          <p className="text-base sm:text-lg leading-relaxed mb-5 text-white">
             Wnioski do KRS składa się wyłącznie elektronicznie: przez PRS (pełna funkcjonalność) lub S24 (uproszczony system dla prostych przypadków, z użyciem wzorców umów). Oba wymagają podpisu kwalifikowanego lub profilu zaufanego.
           </p>
 
@@ -195,7 +195,7 @@ export default function Trust() {
             Przedsiębiorcy kierujący się do sądu rejestrowego w celu aktualizacji danych w KRS.
           </p>
 
-          <h2 className="text-2xl font-semibold mt-10 mb-4 text-white">
+          <h2 className="text-2xl font-semibold mt-8 mb-3 text-white">
             Repozytorium dokumentów KRS
           </h2>
 


### PR DESCRIPTION
## Summary
- reduce hero padding and margins to bring copy and buttons closer together
- tighten spacing inside the features grid for a more compact block
- compress padding and vertical rhythm within the trust sections to eliminate large gaps

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e62bc1b2388330a314b6b9ec53f10a