### PR TITLE
Darken pricing page background overlay

### DIFF
--- a/app/(site)/cennik/page.tsx
+++ b/app/(site)/cennik/page.tsx
@@ -137,7 +137,7 @@ export default function PricingPage() {
       </Script>
 
       <div
-        className="fixed inset-0 -z-10 bg-slate-900/75"
+        className="fixed inset-0 -z-10 bg-slate-950/80"
         style={{
           backgroundImage: `url(${professionalWaitingRoomImage.src})`,
           backgroundSize: "cover",


### PR DESCRIPTION
## Summary
- darken the pricing page overlay to better match the rest of the site backgrounds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e64a4f99c48330846d05db552ed7b0