### PR TITLE
Update prokurent-krs schema type and metadata branding

### DIFF
--- a/app/(site)/uslugi/prokurent-krs/page.tsx
+++ b/app/(site)/uslugi/prokurent-krs/page.tsx
@@ -14,7 +14,7 @@ const pageUrl = `${siteUrl}${pagePath}`
 
 const legalServiceSchema = {
   "@context": "https://schema.org",
-  "@type": "LegalService",
+  "@type": "Service",
   name: "Prokurent w spółce – ustanowienie prokury i wpis do KRS",
   url: pageUrl,
   provider: organizationSchema,
@@ -23,7 +23,7 @@ const legalServiceSchema = {
     price: "799",
     priceCurrency: "PLN",
   },
-  areaServed: { "@type": "Country", name: "Polska" },
+  areaServed: { "@type": "Country", name: "Poland" },
 }
 
 const faqSchema = {
@@ -99,22 +99,23 @@ const breadcrumbSchema = {
 }
 
 export const metadata: Metadata = {
-  title: "Prokurent w spółce – ustanowienie prokury i wpis do KRS | ZmianaKRS.pl",
+  title: "Prokurent w spółce – ustanowienie prokury i wpis do KRS | ZmianaKRS",
   description:
     "Ustanowienie prokurenta, powołanie lub odwołanie prokury i wpis do KRS. Przygotujemy dokumenty i złożymy wniosek w PRS lub S24 za Ciebie. Obsługa od 799 zł netto.",
   alternates: { canonical: pageUrl },
   openGraph: {
-    title: "Prokurent w spółce – ustanowienie prokury i wpis do KRS | ZmianaKRS.pl",
+    title: "Prokurent w spółce – ustanowienie prokury i wpis do KRS | ZmianaKRS",
     description:
       "Ustanowienie prokurenta, powołanie lub odwołanie prokury i wpis do KRS. Przygotujemy dokumenty i złożymy wniosek w PRS lub S24 za Ciebie. Obsługa od 799 zł netto.",
     url: pageUrl,
     siteName: brandName,
-    images: [{ url: `${siteUrl}/images/krs-services.png`, width: 1200, height: 630, alt: "Prokurent w spółce – ZmianaKRS.pl" }],
+    images: [{ url: `${siteUrl}/images/krs-services.png`, width: 1200, height: 630, alt: "Prokurent w spółce – ZmianaKRS" }],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Prokurent w spółce – ustanowienie prokury i wpis do KRS | ZmianaKRS.pl",
-    description: "Ustanowienie prokurenta, powołanie lub odwołanie prokury i wpis do KRS. Obsługa od 799 zł netto.",
+    title: "Prokurent w spółce – ustanowienie prokury i wpis do KRS | ZmianaKRS",
+    description:
+      "Ustanowienie prokurenta, powołanie lub odwołanie prokury i wpis do KRS. Przygotujemy dokumenty i złożymy wniosek w PRS lub S24 za Ciebie. Obsługa od 799 zł netto.",
     images: [`${siteUrl}/images/krs-services.png`],
   },
 }


### PR DESCRIPTION
### Motivation
- Standardize structured data type and internationalize area served value for the Prokurent KRS service page.
- Remove the ".pl" suffix from branding in page metadata to match site naming conventions and keep social previews consistent.

### Description
- Changed `legalServiceSchema.@type` from `LegalService` to `Service` in `app/(site)/uslugi/prokurent-krs/page.tsx`.
- Updated `legalServiceSchema.areaServed` country name from `{"@type": "Country", name: "Polska"}` to `{"@type": "Country", name: "Poland"}`.
- Left `provider: organizationSchema` unchanged as requested.
- Updated metadata branding strings in `app/(site)/uslugi/prokurent-krs/page.tsx`: replaced `"ZmianaKRS.pl"` with `"ZmianaKRS"` for `metadata.title`, `metadata.openGraph.title`, and `metadata.twitter.title`.
- Set `metadata.twitter.description` to match `metadata.openGraph.description` exactly by replacing the shorter twitter description with the longer openGraph text.
- Updated `metadata.openGraph.images[0].alt` from `"Prokurent w spółce – ZmianaKRS.pl"` to `"Prokurent w spółce – ZmianaKRS"`.
- Only modified file: `app/(site)/uslugi/prokurent-krs/page.tsx` and no other content, layout, links, imports (beyond necessary), or variable names were changed.

### Testing
- Ran `git diff -- 'app/(site)/uslugi/prokurent-krs/page.tsx'` to verify the patch, which showed the intended changes (success).
- Ran `git status --short` to confirm working tree state (success).
- Committed the change with `git add` and `git commit -m 'Update prokurent-krs schema type and metadata branding'`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfaffe00e483309e9d86e4d93ae77b)