### PR TITLE
Unify brand name to 'ZmianaKRS' and update contact email to 'biuro@zmianakrs.pl'

### DIFF
--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -20,7 +20,7 @@ const structuredData = {
   contactPoint: {
     "@type": "ContactPoint",
     telephone: "+48572234779",
-    email: "kontakt@zmianakrs.pl",
+    email: "biuro@zmianakrs.pl",
     contactType: "customer service",
     areaServed: "PL",
     availableLanguage: ["pl-PL"],

--- a/app/(site)/en/contact/page.tsx
+++ b/app/(site)/en/contact/page.tsx
@@ -20,7 +20,7 @@ const structuredData = {
   contactPoint: {
     "@type": "ContactPoint",
     telephone: "+48572234779",
-    email: "kontakt@zmianakrs.pl",
+    email: "biuro@zmianakrs.pl",
     contactType: "customer service",
     areaServed: "PL",
     availableLanguage: ["en"],

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,8 +11,8 @@ export const metadata: Metadata = {
     process.env.NEXT_PUBLIC_SITE_URL ?? 'https://zmianakrs.pl'
   ),
   title: {
-    default: 'Zmiana KRS – zmiana wpisu w KRS dla spółek',
-    template: '%s | Zmiana KRS',
+    default: 'ZmianaKRS – zmiana wpisu w KRS dla spółek',
+    template: '%s | ZmianaKRS',
   },
   description:
     'Profesjonalna obsługa zmian w KRS dla spółek – zmiana zarządu, umowy spółki, danych w KRS.',

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -53,7 +53,7 @@ export default function Footer({
           ) : (
             <div className="flex flex-col items-start gap-8 lg:flex-row lg:items-center lg:gap-12">
               <div>
-                <h3 className="mb-1 text-sm font-bold">Zmiana KRS</h3>
+                <h3 className="mb-1 text-sm font-bold">ZmianaKRS</h3>
                 <p className="text-xs text-gray-300">
                   Profesjonalne usługi KRS dla Twojej firmy.
                 </p>
@@ -286,7 +286,7 @@ export default function Footer({
 
         <div className="mt-6 border-t border-gray-700 pt-4 text-left">
           <p className="text-xs text-gray-300">
-            &copy; {currentYear} Zmiana KRS. Wszystkie prawa zastrzeżone.
+            &copy; {currentYear} ZmianaKRS. Wszystkie prawa zastrzeżone.
           </p>
         </div>
       </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -56,7 +56,7 @@ export default function Navbar() {
             {"572\u202f234\u202f779"}
           </a>
           <a
-            href="mailto:kontakt@zmianakrs.pl"
+            href="mailto:biuro@zmianakrs.pl"
             className="flex items-center gap-2 text-amber-800 transition-colors hover:text-amber-700 md:font-bold"
           >
             <svg
@@ -68,7 +68,7 @@ export default function Navbar() {
             >
               <path d="M4 5c-1.105 0-2 .895-2 2v10c0 1.105.895 2 2 2h16c1.105 0 2-.895 2-2V7c0-1.105-.895-2-2-2H4zm0 2h16v.01L12 13 4 7.01V7zm0 3.236 7.445 4.591a1 1 0 0 0 1.11 0L20 10.236V17H4v-6.764z" />
             </svg>
-            kontakt@zmianakrs.pl
+            biuro@zmianakrs.pl
           </a>
         </div>
 


### PR DESCRIPTION
### Motivation
- Standardize the public brand label and contact details used across the site for consistency and to route incoming mail to the official inbox.
- Ensure structured data and visible contact links reflect the updated support email for both Polish and English pages.

### Description
- Replaced `kontakt@zmianakrs.pl` with `biuro@zmianakrs.pl` in structured data on the Polish and English contact pages (`app/(site)/contact/page.tsx` and `app/(site)/en/contact/page.tsx`).
- Updated the `mailto:` link and visible email in the header (`components/Navbar.tsx`) to `biuro@zmianakrs.pl`.
- Normalized the brand text from `Zmiana KRS` to `ZmianaKRS` in the site metadata (`app/layout.tsx`) and footer display/copyright (`components/Footer.tsx`).

### Testing
- Ran the TypeScript type check and the project build with `pnpm build`, and they completed successfully.
- Ran linting with `pnpm lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f881ae54a8833090b39e74aee7cd64)