### PR TITLE
Remove ".pl" from metadata titles and update favicon aria-label

### DIFF
--- a/app/(site)/cennik/page.tsx
+++ b/app/(site)/cennik/page.tsx
@@ -88,12 +88,12 @@ const structuredData = {
 }
 
 export const metadata: Metadata = {
-  title: "Ile kosztuje zmiana wpisu w KRS? Cennik usług | ZmianaKRS.pl",
+  title: "Ile kosztuje zmiana wpisu w KRS? Cennik usług | ZmianaKRS",
   description:
     "Sprawdź cennik zmian w KRS: złożenie wniosku od 799 zł, przygotowanie dokumentów od 50 zł, założenie spółki od 699 zł. Opłata sądowa 250 zł lub 200 zł przez S24. Przejrzyste ceny, bez ukrytych kosztów.",
   alternates: { canonical: pageUrl },
   openGraph: {
-    title: "Ile kosztuje zmiana wpisu w KRS? Cennik usług | ZmianaKRS.pl",
+    title: "Ile kosztuje zmiana wpisu w KRS? Cennik usług | ZmianaKRS",
     description:
       "Sprawdź cennik zmian w KRS: złożenie wniosku od 799 zł, przygotowanie dokumentów od 50 zł, założenie spółki od 699 zł. Opłata sądowa 250 zł lub 200 zł przez S24. Przejrzyste ceny, bez ukrytych kosztów.",
     url: pageUrl,
@@ -102,7 +102,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Ile kosztuje zmiana wpisu w KRS? Cennik usług | ZmianaKRS.pl",
+    title: "Ile kosztuje zmiana wpisu w KRS? Cennik usług | ZmianaKRS",
     description:
       "Sprawdź cennik zmian w KRS: złożenie wniosku od 799 zł, przygotowanie dokumentów od 50 zł, założenie spółki od 699 zł. Opłata sądowa 250 zł lub 200 zł przez S24. Przejrzyste ceny, bez ukrytych kosztów.",
     images: [`${siteUrl}/images/krs-services.png`],

--- a/app/(site)/ksiegowi/page.tsx
+++ b/app/(site)/ksiegowi/page.tsx
@@ -25,14 +25,14 @@ const structuredData = {
 }
 
 export const metadata: Metadata = {
-  title: "Obsługa KRS dla biur rachunkowych – współpraca B2B | ZmianaKRS.pl",
+  title: "Obsługa KRS dla biur rachunkowych – współpraca B2B | ZmianaKRS",
   description:
     "Profesjonalne wsparcie w zmianach wpisów KRS dla biur rachunkowych. Przejmujemy formalności rejestrowe Twoich klientów – dokumenty, wnioski, kontakt z sądem. Sprawdź warunki współpracy.",
   alternates: {
     canonical: pageUrl,
   },
   openGraph: {
-    title: "Obsługa KRS dla biur rachunkowych – współpraca B2B | ZmianaKRS.pl",
+    title: "Obsługa KRS dla biur rachunkowych – współpraca B2B | ZmianaKRS",
     description:
       "Profesjonalne wsparcie w zmianach wpisów KRS dla biur rachunkowych. Przejmujemy formalności rejestrowe Twoich klientów – dokumenty, wnioski, kontakt z sądem. Sprawdź warunki współpracy.",
     url: pageUrl,
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Obsługa KRS dla biur rachunkowych – współpraca B2B | ZmianaKRS.pl",
+    title: "Obsługa KRS dla biur rachunkowych – współpraca B2B | ZmianaKRS",
     description:
       "Profesjonalne wsparcie w zmianach wpisów KRS dla biur rachunkowych. Przejmujemy formalności rejestrowe Twoich klientów – dokumenty, wnioski, kontakt z sądem. Sprawdź warunki współpracy.",
     images: [`${siteUrl}/images/krs-services.png`],

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -15,7 +15,7 @@ const pageUrl = siteUrl
 
 export const metadata: Metadata = {
   title:
-    "Zmiana wpisu w KRS dla spółek – od 799 zł, zdalnie | ZmianaKRS.pl",
+    "Zmiana wpisu w KRS dla spółek – od 799 zł, zdalnie | ZmianaKRS",
   description:
     "Profesjonalna zmiana zarządu, adresu, wspólnika lub umowy spółki w KRS. Przygotujemy dokumenty i złożymy wniosek za Ciebie. Szybko, bez błędów, od 799 zł netto.",
   alternates: {
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title:
-      "Zmiana wpisu w KRS dla spółek – od 799 zł, zdalnie | ZmianaKRS.pl",
+      "Zmiana wpisu w KRS dla spółek – od 799 zł, zdalnie | ZmianaKRS",
     description:
       "Profesjonalna zmiana zarządu, adresu, wspólnika lub umowy spółki w KRS. Przygotujemy dokumenty i złożymy wniosek za Ciebie. Szybko, bez błędów, od 799 zł netto.",
     url: pageUrl,
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title:
-      "Zmiana wpisu w KRS dla spółek – od 799 zł, zdalnie | ZmianaKRS.pl",
+      "Zmiana wpisu w KRS dla spółek – od 799 zł, zdalnie | ZmianaKRS",
     description:
       "Profesjonalna zmiana zarządu, adresu, wspólnika lub umowy spółki w KRS. Przygotujemy dokumenty i złożymy wniosek za Ciebie. Szybko, bez błędów, od 799 zł netto.",
     images: [

--- a/app/(site)/uslugi/page.tsx
+++ b/app/(site)/uslugi/page.tsx
@@ -164,7 +164,7 @@ const structuredData = {
 
 export const metadata: Metadata = {
   title:
-    "Usługi zmian wpisu w KRS dla spółek – obsługa wniosków KRS | ZmianaKRS.pl",
+    "Usługi zmian wpisu w KRS dla spółek – obsługa wniosków KRS | ZmianaKRS",
   description:
     "Profesjonalne usługi zmian wpisu w KRS dla spółek – przygotowanie dokumentów, obsługa wniosków KRS i zakładanie spółek z o.o. Zajmujemy się zmianą danych spółki w KRS od analizy dokumentów po wpis zmian do rejestru.",
   alternates: {
@@ -172,7 +172,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title:
-      "Usługi zmian wpisu w KRS dla spółek – obsługa wniosków KRS | ZmianaKRS.pl",
+      "Usługi zmian wpisu w KRS dla spółek – obsługa wniosków KRS | ZmianaKRS",
     description:
       "Kompleksowa obsługa wniosków o zmianę wpisu w KRS, rejestracji spółek z o.o. oraz dokumentów zgromadzeń wspólników.",
     url: pageUrl,

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Zmiana KRS favicon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="ZmianaKRS favicon">
   <defs>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#ff7a00"/>


### PR DESCRIPTION
### Motivation

- Unify site branding by removing the ".pl" suffix from page metadata titles and social metadata so the brand reads as "ZmianaKRS" consistently.
- Improve accessibility/consistency of the favicon by updating its `aria-label` to match the brand name.

### Description

- Updated `metadata.title`, `openGraph.title`, and `twitter.title` to remove the ".pl" suffix across the landing, services, pricing, and accountants pages (`app/(site)/page.tsx`, `app/(site)/uslugi/page.tsx`, `app/(site)/cennik/page.tsx`, `app/(site)/ksiegowi/page.tsx`).
- Adjusted the favicon `aria-label` in `public/favicon.svg` from "Zmiana KRS favicon" to "ZmianaKRS favicon" to match the branding.
- Left other content, structured data, and assets unchanged to preserve SEO descriptions and images.

### Testing

- Ran TypeScript check via `npm run typecheck` and it completed successfully.
- Performed a production build with `npm run build` and the build succeeded without errors.
- Ran linting with `npm run lint` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89503fcd08330b87722ae29e4a9ef)