### PR TITLE
Allow indexing for legal pages and add www -> apex redirect

### DIFF
--- a/app/(site)/polityka-prywatnosci/page.tsx
+++ b/app/(site)/polityka-prywatnosci/page.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   description:
     "Dowiedz się jak chronimy Twoje dane osobowe podczas obsługi wniosków KRS. Zgodność z RODO i zasady przetwarzania danych klientów.",
   alternates: { canonical: pageUrl },
-  robots: { index: false, follow: true },
+  robots: { index: true, follow: true },
   openGraph: {
     title: "Polityka prywatności | ZmianaKRS",
     description: "Dowiedz się jak chronimy Twoje dane osobowe podczas obsługi wniosków KRS.",

--- a/app/(site)/regulamin/page.tsx
+++ b/app/(site)/regulamin/page.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   description:
     "Zapoznaj się z regulaminem świadczenia usług obsługi wniosków KRS. Warunki współpracy, prawa i obowiązki stron w procesie zmiany wpisu.",
   alternates: { canonical: pageUrl },
-  robots: { index: false, follow: true },
+  robots: { index: true, follow: true },
   openGraph: {
     title: "Regulamin świadczenia usług | ZmianaKRS",
     description: "Zapoznaj się z regulaminem świadczenia usług obsługi wniosków KRS.",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,12 @@ const nextConfig = {
   experimental: { mdxRs: true },
   async redirects() {
     return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.zmianakrs.pl" }],
+        destination: "https://zmianakrs.pl/:path*",
+        permanent: true,
+      },
       { source: "/contact", destination: "/kontakt", permanent: true },
       { source: "/dla-ksiegowych", destination: "/ksiegowi", permanent: true },
     ]


### PR DESCRIPTION
### Motivation

- Make the site legal pages discoverable by search engines by enabling indexing for the privacy and terms pages.
- Ensure a single canonical hostname by redirecting traffic from `www.zmianakrs.pl` to `zmianakrs.pl` to avoid duplicate-content and cookie/SEO inconsistencies.

### Description

- Changed `robots` metadata on `/polityka-prywatnosci` and `/regulamin` pages from `{ index: false, follow: true }` to `{ index: true, follow: true }` so search engines can index these pages.
- Added a permanent host-based redirect in `next.config.mjs` to forward requests from `www.zmianakrs.pl/:path*` to `https://zmianakrs.pl/:path*` while preserving the path.
- Kept the existing SEO structured data and Open Graph metadata intact for both pages.

### Testing

- Ran a production build with `next build` which completed successfully.
- Ran lint/type-check with `npm run lint` and TypeScript checks which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e45c6e448330b8534215e32e71d0)