### PR TITLE
Emit gtag `generate_lead` event on successful contact form submissions

### DIFF
--- a/app/(site)/contact/contact-content.tsx
+++ b/app/(site)/contact/contact-content.tsx
@@ -14,6 +14,12 @@ import { apiRequest } from "@/lib/queryClient"
 import { MapPin, Phone, Mail, Clock } from "lucide-react"
 import Link from "next/link"
 
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
 const contactFormSchema = z.object({
   fullName: z.string().trim().min(3, "Imię i nazwisko musi mieć co najmniej 3 znaki"),
   email: z.string().email("Nieprawidłowy adres email"),
@@ -53,6 +59,13 @@ export default function ContactPageContent() {
         data,
       }),
     onSuccess: () => {
+      if (typeof window !== "undefined" && typeof window.gtag === "function") {
+        window.gtag("event", "generate_lead", {
+          form_name: "contact_page_form",
+          method: "contact_form",
+          page_path: window.location.pathname,
+        })
+      }
       setSubmissionStatus({
         type: "success",
         message: "Wiadomość została wysłana. Odezwiemy się bezzwłocznie.",

--- a/app/(site)/en/contact/contact-content.tsx
+++ b/app/(site)/en/contact/contact-content.tsx
@@ -14,6 +14,12 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { apiRequest } from "@/lib/queryClient"
 import { MapPin, Phone, Mail, Clock } from "lucide-react"
 
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
 const contactFormSchema = z.object({
   fullName: z.string().trim().min(3, "Full name must be at least 3 characters"),
   email: z.string().email("Invalid email address"),
@@ -53,6 +59,13 @@ export default function ContactPageContent() {
         data,
       }),
     onSuccess: () => {
+      if (typeof window !== "undefined" && typeof window.gtag === "function") {
+        window.gtag("event", "generate_lead", {
+          form_name: "contact_page_form_en",
+          method: "contact_form",
+          page_path: window.location.pathname,
+        })
+      }
       setSubmissionStatus({
         type: "success",
         message: "Your message has been sent. We will respond promptly.",

--- a/app/(site)/uslugi/_components/InlineContactForm.tsx
+++ b/app/(site)/uslugi/_components/InlineContactForm.tsx
@@ -14,6 +14,12 @@ import { Textarea } from "@/components/ui/textarea"
 import { apiRequest } from "@/lib/queryClient"
 import { cn } from "@/lib/utils"
 
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
 const contactFormSchema = z.object({
   fullName: z.string().trim().min(3, "Imię i nazwisko musi mieć co najmniej 3 znaki"),
   email: z.string().email("Nieprawidłowy adres email"),
@@ -56,6 +62,13 @@ export default function InlineContactForm({ className }: InlineContactFormProps)
         data,
       }),
     onSuccess: () => {
+      if (typeof window !== "undefined" && typeof window.gtag === "function") {
+        window.gtag("event", "generate_lead", {
+          form_name: "inline_contact_form",
+          method: "contact_form",
+          page_path: window.location.pathname,
+        })
+      }
       setSubmissionStatus({
         type: "success",
         message: "Wiadomość została wysłana. Odezwiemy się bezzwłocznie.",

--- a/app/(site)/uslugi/_components/InlineContactFormEn.tsx
+++ b/app/(site)/uslugi/_components/InlineContactFormEn.tsx
@@ -14,6 +14,12 @@ import { Textarea } from "@/components/ui/textarea"
 import { apiRequest } from "@/lib/queryClient"
 import { cn } from "@/lib/utils"
 
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
 const contactFormSchema = z.object({
   fullName: z.string().trim().min(3, "Full name must be at least 3 characters"),
   email: z.string().email("Invalid email address"),
@@ -56,6 +62,13 @@ export default function InlineContactFormEn({ className }: InlineContactFormProp
         data,
       }),
     onSuccess: () => {
+      if (typeof window !== "undefined" && typeof window.gtag === "function") {
+        window.gtag("event", "generate_lead", {
+          form_name: "inline_contact_form_en",
+          method: "contact_form",
+          page_path: window.location.pathname,
+        })
+      }
       setSubmissionStatus({
         type: "success",
         message: "Your message has been sent. We will get back to you shortly.",


### PR DESCRIPTION
### Motivation
- Add client-side analytics reporting so successful contact form submissions are tracked as leads across pages and locales.

### Description
- Add a global `window.gtag` TypeScript declaration to client components to avoid typing errors when calling `gtag`.
- Emit a `gtag("event", "generate_lead", {...})` call in the `onSuccess` handler of the contact submission mutation in four components: the Polish and English contact pages and the inline contact forms.
- Include `form_name`, `method`, and `page_path` in the event payload; use locale-specific `form_name` values like `contact_page_form_en` and `inline_contact_form_en`.

### Testing
- Ran TypeScript check with `tsc --noEmit`, which completed successfully.
- Performed a Next.js build with `next build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0196a5fcc8833082d59e14682f2c98)